### PR TITLE
Bugfix: Call-time pass-by-reference was removed from PHP 5.4.

### DIFF
--- a/volunteer.php
+++ b/volunteer.php
@@ -20,7 +20,7 @@ function volunteer_civicrm_xmlMenu(&$files) {
 
 /**                                                                                                                                                                                                       * Implementation of hook_civicrm_xmlMenu                                                                                                                                                                 *                                                                                                                                                                                                        * @param $files array(string)                                                                                                                                                                            */
 function volunteer_civicrm_eventTabs(&$tabs, $eventID ) {
-    _volunteer_civix_civicrm_eventTabs(&$tabs, $eventID );
+    _volunteer_civix_civicrm_eventTabs($tabs, $eventID );
 }
 
 /**


### PR DESCRIPTION
Fix prevents fatal error.
