### PR TITLE
Add "Volunteer Now" button to info pages of events which have associated projects.

### DIFF
--- a/templates/CRM/Event/Page/EventInfo.css
+++ b/templates/CRM/Event/Page/EventInfo.css
@@ -1,0 +1,8 @@
+#crm-container .actionlinks-bottom {
+  clear:both;
+  height: 27px;
+}
+#crm-container .register_link-bottom {
+  float: left;
+  padding-left: 8px;
+}

--- a/templates/CRM/Event/Page/volunteer-button.tpl
+++ b/templates/CRM/Event/Page/volunteer-button.tpl
@@ -23,7 +23,7 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-<div class="action-link section register_link-section register_link-{$snippet.position}">
+<div class="action-link section volunteer_link-section register_link-{$snippet.position}">
   <a href="{$snippet.url}" title="{$snippet.button_text}" class="button crm-volunteer_signup-button">
     <span>{$snippet.button_text}</span>
   </a>

--- a/volunteer.php
+++ b/volunteer.php
@@ -173,7 +173,7 @@ function _volunteer_civicrm_pageRun_CRM_Event_Page_EventInfo(&$page) {
     $snippet['weight'] = 10;
     CRM_Core_Region::instance('event-page-eventinfo-actionlinks-bottom')->add($snippet);
 
-    CRM_Core_Resources::singleton()->addStyleUrl('org.civicrm.volunteer',
+    CRM_Core_Resources::singleton()->addStyleFile('org.civicrm.volunteer',
       'templates/CRM/Event/Page/EventInfo.css'
     );
   }


### PR DESCRIPTION
This approach uses CRM_Core_Region instead of JavaScript. It depends on the following change to core: https://github.com/civicrm/civicrm-core/pull/1163.

It _should_ work, but it doesn't. If I use the html-header region instead of any of the regions in use, it works as expected.
