### PR TITLE
Resolves "Failed to determine field name for 'id'" errors when doing API gets for Need or Project entities using id fields.

### DIFF
--- a/CRM/Volunteer/DAO/Need.php
+++ b/CRM/Volunteer/DAO/Need.php
@@ -178,13 +178,13 @@ class CRM_Volunteer_DAO_Need extends CRM_Core_DAO
   {
     if (!(self::$_fields)) {
       self::$_fields = array(
-        'civicrm_volunteer_need_id' => array(
+        'volunteer_need_id' => array(
           'name' => 'id',
           'type' => CRM_Utils_Type::T_INT,
           'title' => ts('CiviVolunteer Need ID') ,
           'required' => true,
         ) ,
-        'civicrm_volunteer_need_project_id' => array(
+        'volunteer_need_project_id' => array(
           'name' => 'project_id',
           'type' => CRM_Utils_Type::T_INT,
           'required' => true,
@@ -249,8 +249,8 @@ class CRM_Volunteer_DAO_Need extends CRM_Core_DAO
   {
     if (!(self::$_fieldKeys)) {
       self::$_fieldKeys = array(
-        'id' => 'civicrm_volunteer_need_id',
-        'project_id' => 'civicrm_volunteer_need_project_id',
+        'id' => 'volunteer_need_id',
+        'project_id' => 'volunteer_need_project_id',
         'start_time' => 'start_time',
         'duration' => 'duration',
         'is_flexible' => 'is_flexible',

--- a/CRM/Volunteer/DAO/Project.php
+++ b/CRM/Volunteer/DAO/Project.php
@@ -133,7 +133,7 @@ class CRM_Volunteer_DAO_Project extends CRM_Core_DAO
   {
     if (!(self::$_fields)) {
       self::$_fields = array(
-        'civicrm_volunteer_project_id' => array(
+        'volunteer_project_id' => array(
           'name' => 'id',
           'type' => CRM_Utils_Type::T_INT,
           'title' => ts('CiviVolunteer Project ID') ,
@@ -174,7 +174,7 @@ class CRM_Volunteer_DAO_Project extends CRM_Core_DAO
   {
     if (!(self::$_fieldKeys)) {
       self::$_fieldKeys = array(
-        'id' => 'civicrm_volunteer_project_id',
+        'id' => 'volunteer_project_id',
         'entity_table' => 'entity_table',
         'entity_id' => 'entity_id',
         'is_active' => 'is_active',

--- a/xml/schema/Volunteer/Need.xml
+++ b/xml/schema/Volunteer/Need.xml
@@ -8,7 +8,7 @@
   <log>true</log>
   <field>
     <name>id</name>
-    <uniqueName>civicrm_volunteer_need_id</uniqueName>
+    <uniqueName>volunteer_need_id</uniqueName>
     <title>CiviVolunteer Need ID</title>
     <type>int unsigned</type>
     <required>true</required>
@@ -23,7 +23,7 @@
     <name>project_id</name>
     <type>int unsigned</type>
     <required>true</required>
-    <uniqueName>civicrm_volunteer_need_project_id</uniqueName>
+    <uniqueName>volunteer_need_project_id</uniqueName>
     <comment>FK to civicrm_volunteer_project table which contains entity_table + entity for each volunteer project (initially civicrm_event + eventID).</comment>
     <add>4.4</add>
   </field>

--- a/xml/schema/Volunteer/Project.xml
+++ b/xml/schema/Volunteer/Project.xml
@@ -8,7 +8,7 @@
   <log>true</log>
   <field>
     <name>id</name>
-    <uniqueName>civicrm_volunteer_project_id</uniqueName>
+    <uniqueName>volunteer_project_id</uniqueName>
     <title>CiviVolunteer Project ID</title>
     <type>int unsigned</type>
     <required>true</required>


### PR DESCRIPTION
The undefined_fields key is still improperly set and needs to be addressed, but the API is now usable at least.
