### PR TITLE
CRM-12842 - Hide Volunteer Now button on event/info if user does not hav...

### DIFF
--- a/CRM/Volunteer/Form/VolunteerSignUp.php
+++ b/CRM/Volunteer/Form/VolunteerSignUp.php
@@ -219,9 +219,9 @@ class CRM_Volunteer_Form_VolunteerSignUp extends CRM_Core_Form {
     $cid = CRM_Utils_Array::value('userID', $_SESSION['CiviCRM'], NULL);
     $values = $this->controller->exportValues();
 
-    // if role id matches flexible role id constant, ignore the submitted need
-    // id and use the need id of the flexible need
-    if ((int) CRM_Utils_Array::value('volunteer_role_id', $values) === self::FLEXIBLE_ROLE_ID) {
+    // Role id is not present in form $values when the only public need is the flexible need.
+    // So if role id is net set OR if it matches flexible role id constant then use the flexible need id
+    if (! isset($values['volunteer_role_id']) || (int) CRM_Utils_Array::value('volunteer_role_id', $values) === self::FLEXIBLE_ROLE_ID) {
       foreach ($this->_needs as $n) {
         if ($n['is_flexible'] === '1') {
           $values['volunteer_need_id'] = $n['id'];

--- a/volunteer.php
+++ b/volunteer.php
@@ -177,8 +177,8 @@ function _volunteer_civicrm_pageRun_CRM_Event_Page_EventInfo(&$page) {
   );
   $projects = CRM_Volunteer_BAO_Project::retrieve($params);
 
-  // show volunteer button only if this event has an active project
-  if (count($projects)) {
+  // show volunteer button only if user has CiviVolunteer: register to volunteer AND this event has an active project
+  if (CRM_Core_Permission::check('register to volunteer') && count($projects)) {
     $project = current($projects);
     $url = CRM_Utils_System::url('civicrm/volunteer/signup', array(
       'reset' => 1,


### PR DESCRIPTION
...e register to volunteer permission. Fix VolunteerSignUp form to not throw fatal in postProcess when the role_id and need_id are not present in submitted values (this happens when the only public need is the one flexible need).
