### PR TITLE
Minimal tests for Volunteer Need API

### DIFF
--- a/tests/phpunit/VolunteerTestAbstract.php
+++ b/tests/phpunit/VolunteerTestAbstract.php
@@ -1,0 +1,41 @@
+<?php
+
+require_once 'CiviTest/CiviUnitTestCase.php';
+
+/**
+ * Abstract class for Volunteer tests
+ */
+abstract class VolunteerTestAbstract extends CiviUnitTestCase {
+
+  /**
+   * Ensure that, if the database is repopulated, CiviVolunteer's install
+   * operations are run, adding custom option group, activity fields, etc. to
+   * the testing db.
+   *
+   * @param type $perClass
+   * @param type $object
+   * @return boolean
+   */
+  protected static function _populateDB($perClass = FALSE, &$object = NULL) {
+    if (!parent::_populateDB($perClass, $object)) {
+      return FALSE;
+    }
+
+    // code adapted from CRM_Volunteer_Upgrader::install().
+    $upgrader = new CRM_Volunteer_Upgrader('org.civicrm.volunteer', dirname(__FILE__) . '/../../');
+
+    $activityTypeId = $upgrader->findCreateVolunteerActivityType();
+    $smarty = CRM_Core_Smarty::singleton();
+    $smarty->assign('volunteer_custom_activity_type_name', CRM_Volunteer_Upgrader::customActivityTypeName);
+    $smarty->assign('volunteer_custom_group_name', CRM_Volunteer_Upgrader::customGroupName);
+    $smarty->assign('volunteer_custom_option_group_name', CRM_Volunteer_Upgrader::customOptionGroupName);
+    $smarty->assign('volunteer_activity_type_id', $activityTypeId);
+
+    $customIDs = $upgrader->findCustomGroupValueIDs();
+    $smarty->assign('customIDs', $customIDs);
+
+    $upgrader->executeCustomDataTemplateFile('volunteer-customdata.xml.tpl');
+    $upgrader->createVolunteerActivityStatus();
+    return TRUE;
+  }
+}

--- a/tests/phpunit/api/v3/VolunteerNeedTest.php
+++ b/tests/phpunit/api/v3/VolunteerNeedTest.php
@@ -1,0 +1,57 @@
+<?php
+
+require_once 'VolunteerTestAbstract.php';
+
+/**
+ * Test class for Volunteer Need API - volunteer_need
+ */
+class api_v3_VolunteerNeedTest extends VolunteerTestAbstract {
+  static protected $_params;
+  static protected $_project_id;
+
+  function setUp() {
+    $this->quickCleanup(array('civicrm_volunteer_need', 'civicrm_volunteer_project'));
+    parent::setUp();
+  }
+
+  /**
+   * Test simple create via API
+   */
+  function testCreateNeed() {
+    $project = CRM_Core_DAO::createTestObject('CRM_Volunteer_BAO_Project');
+    $this->assertObjectHasAttribute('id', $project, 'Failed to prepopulate Volunteer Project');
+
+    $params = array(
+      "project_id"    => $project->id,
+      "start_time"    => "2013-12-17 16:00:00",
+      "duration"      => 240,
+      "is_flexible"   => 0,
+      "quantity"      => 1,
+      "visibility_id" => CRM_Core_OptionGroup::getValue('visibility', 'public', 'name'),
+      "role_id"       => 1,
+      "is_active"     => 1,
+    );
+
+    $this->callAPIAndDocument('VolunteerNeed', 'create', $params, __FUNCTION__, __FILE__);
+  }
+
+  /**
+   * Test simple delete via API
+   */
+  function testDeleteNeedbyID() {
+    $need = CRM_Core_DAO::createTestObject('CRM_Volunteer_BAO_Need');
+    $this->assertObjectHasAttribute('id', $need, 'Failed to prepopulate Volunteer Need');
+
+    $this->callAPIAndDocument('VolunteerNeed', 'delete', array('id' => $need->id), __FUNCTION__, __FILE__);
+  }
+
+  /**
+   * Test simple get via API
+   */
+  function testGetNeedbyID() {
+    $need = CRM_Core_DAO::createTestObject('CRM_Volunteer_BAO_Need');
+    $this->assertObjectHasAttribute('id', $need, 'Failed to prepopulate Volunteer Need');
+
+    $this->callAPIAndDocument('VolunteerNeed', 'get', array('id' => $need->id), __FUNCTION__, __FILE__);
+  }
+}


### PR DESCRIPTION
Also, addition of abstract class for all CiviVolunteer tests to extend so that the data provided by the extension (e.g. custom fields, option groups, etc.) is available to the tests.
