### PR TITLE
Add api permission hook for "Assign Volunteers"

### DIFF
--- a/volunteer.php
+++ b/volunteer.php
@@ -345,12 +345,10 @@ function _volunteer_civicrm_check_resource_url() {
 }
 
 /**
- *  alterAPIPermissions() hook allows you to change the permissions checked when doing API 3 calls.
+ * Implements hook_civicrm_alterAPIPermissions 
  */
-function volunteer_civicrm_alterAPIPermissions($entity, $action, &$params, &$permissions)
-{
-    // skip permission checks for volunteer_need/get calls
-    // note: unsetting the below would require the default ‘administer CiviCRM’ permission
+function volunteer_civicrm_alterAPIPermissions($entity, $action, &$params, &$permissions) {    
+// note: unsetting the below would require the default ‘administer CiviCRM’ permission
   $permissions['volunteer_need']['default'] = array('access CiviEvent', 'edit all events');
   $permissions['volunteer_assignment']['default'] = array('access CiviEvent', 'edit all events');
 }


### PR DESCRIPTION
Without this hook, "Administer CiviCRM" permission must be granted in
Drupal to assign volunteers to an event.
Also need to give Drupal permission "View All Activities."
