### PR TITLE
Updates for 4.5.3

### DIFF
--- a/CRM/Volunteer/Form/Manage.php
+++ b/CRM/Volunteer/Form/Manage.php
@@ -32,16 +32,16 @@ class CRM_Volunteer_Form_Manage {
    */
   public static function addResources($entity_id, $entity_table) {
     static $loaded = FALSE;
-    if ($loaded) {
+    $ccr = CRM_Core_Resources::singleton();
+    if ($loaded || $ccr->isAjaxMode()) {
       return;
     }
     $loaded = TRUE;
     $config = CRM_Core_Config::singleton();
-    $ccr = CRM_Core_Resources::singleton();
 
     // Vendor libraries
     $ccr->addScriptFile('civicrm', 'packages/backbone/json2.js', 100, 'html-header', FALSE);
-    $ccr->addScriptFile('civicrm', 'packages/backbone/backbone-min.js', 120, 'html-header');
+    $ccr->addScriptFile('civicrm', 'packages/backbone/backbone-min.js', 120, 'html-header', FALSE);
     $ccr->addScriptFile('civicrm', 'packages/backbone/backbone.marionette.min.js', 125, 'html-header', FALSE);
 
     // Our stylesheet

--- a/CRM/Volunteer/Form/VolunteerSignUp.php
+++ b/CRM/Volunteer/Form/VolunteerSignUp.php
@@ -134,7 +134,7 @@ class CRM_Volunteer_Form_VolunteerSignUp extends CRM_Core_Form {
   function buildQuickForm() {
     CRM_Utils_System::setTitle(ts('Sign Up to Volunteer for %1', array(1 => $this->_project->title)));
     CRM_Core_Resources::singleton()->addScriptFile('org.civicrm.volunteer',
-      'templates/CRM/Volunteer/Form/VolunteerSignUp.js');
+      'templates/CRM/Volunteer/Form/VolunteerSignUp.js', 500, 'html-header');
 
     $this->buildCustom('volunteerProfile');
 

--- a/js/apps/volunteer_app.js
+++ b/js/apps/volunteer_app.js
@@ -4,7 +4,7 @@ CRM.volunteerApp.addRegions({
   dialogRegion: '#crm-volunteer-dialog'
 });
 
-cj(function($) {
+CRM.$(function($) {
   // Wait for all scripts to load before starting app
   CRM.volunteerApp.start();
 

--- a/templates/CRM/Volunteer/Form/VolunteerSignUp.js
+++ b/templates/CRM/Volunteer/Form/VolunteerSignUp.js
@@ -1,5 +1,5 @@
 // http://civicrm.org/licensing
-cj(function($) {
+CRM.$(function($) {
 
   /**
    * Used to show/hide the Shift dropbox

--- a/volunteer.php
+++ b/volunteer.php
@@ -342,10 +342,10 @@ function _volunteer_civicrm_check_resource_url() {
   );
   $title = json_encode(ts('Error'));
   CRM_Core_Resources::singleton()
-    ->addScriptFile('org.civicrm.volunteer', 'js/checkResourceUrl.js')
-    ->addScript("cj(function() {
+    ->addScriptFile('org.civicrm.volunteer', 'js/checkResourceUrl.js', 0, 'html-header')
+    ->addScript("CRM.$(function() {
       window.civiVolunteerResourceUrlIsOk || CRM.alert($message, $title, 'error');
-    });");
+    });", 1, 'html-header');
 }
 
 /**


### PR DESCRIPTION
Release 4.5.3 fixes a longstanding problem that js resources don't come through ajax snippets.
Unfortunately some scripts had come to rely on that bug/feature so now we need to tell them explicitely not to add resources in ajax mode.
