### PR TITLE
Remove drupal-only css hack

### DIFF
--- a/ang/volunteer.css
+++ b/ang/volunteer.css
@@ -43,10 +43,6 @@
   margin-top: 2em;
 }
 
-#tabs-wrapper {
-  display: none;
-}
-
 .crm-container fieldset.crm-vol-ui-fieldset, fieldset.crm-vol-ui-fieldset {
   border: 1px solid #aaa;
 }


### PR DESCRIPTION
This had the effect of removing titles from all angular pages (but only on certain drupal themes)
e.g. http://dmaster.demo.civicrm.org/civicrm/a/#/status

There's actually a new angular directive in 4.7 which allows you to set the page title, which IMO is better than hiding it:
https://github.com/civicrm/civicrm-core/blob/master/ang/crmUi.js#L985