### PR TITLE
Replace menu-level access control with fine-grained context-aware access control

### DIFF
--- a/CRM/Volunteer/Form/Commendation.php
+++ b/CRM/Volunteer/Form/Commendation.php
@@ -37,6 +37,10 @@ class CRM_Volunteer_Form_Commendation extends CRM_Core_Form {
     $this->_cid = CRM_Utils_Request::retrieve('cid', 'Positive', $this, FALSE);
     $this->_vid = CRM_Utils_Request::retrieve('vid', 'Positive', $this, FALSE);
 
+    if (!CRM_Volunteer_Permission::checkProjectPerms(CRM_Core_Action::UPDATE, $this->_vid)) {
+      CRM_Utils_System::permissionDenied();
+    }
+
     if (!$this->_aid && !($this->_cid && $this->_vid)) {
       CRM_Core_Error::fatal("Form expects an activity ID or both a contact and a volunteer project ID.");
     }

--- a/CRM/Volunteer/Form/Log.php
+++ b/CRM/Volunteer/Form/Log.php
@@ -57,6 +57,11 @@ class CRM_Volunteer_Form_Log extends CRM_Core_Form {
    */
   function preProcess() {
     $this->_vid = CRM_Utils_Request::retrieve('vid', 'Positive', $this, TRUE);
+
+    if (!CRM_Volunteer_Permission::checkProjectPerms(CRM_Core_Action::UPDATE, $this->_vid)) {
+      CRM_Utils_System::permissionDenied();
+    }
+
     $this->_batchInfo['item_count'] = 50;
 
     $params = array('project_id' => $this->_vid);

--- a/CRM/Volunteer/Form/VolunteerSignUp.php
+++ b/CRM/Volunteer/Form/VolunteerSignUp.php
@@ -146,16 +146,7 @@ class CRM_Volunteer_Form_VolunteerSignUp extends CRM_Core_Form {
    * @access public
    */
   function preProcess() {
-    
     $this->redirectLegacyRequests();
-    
-    // VOL-71: permissions check is moved from XML to preProcess function to support
-    // permissions-challenged Joomla instances
-    if (CRM_Core_Config::singleton()->userPermissionClass->isModulePermissionSupported()
-      && !CRM_Volunteer_Permission::check('register to volunteer')
-    ) {
-      CRM_Utils_System::permissionDenied();
-    }
 
     $validNeedIds = array();
     $needs = CRM_Utils_Request::retrieve('needs', 'String', $this, TRUE);

--- a/xml/Menu/Volunteer.xml
+++ b/xml/Menu/Volunteer.xml
@@ -6,8 +6,9 @@
      <title>Batch Data Entry for Logging Volunteer</title>
      <page_callback>CRM_Volunteer_Form_Log</page_callback>
      <path_arguments>action=add</path_arguments>
-     <!-- Access is managed in the preprocessor -->
-     <access_callback>1</access_callback>
+     <!-- Access is further restricted in the preprocessor -->
+     <access_callback>CRM_Volunteer_Permission::check</access_callback>
+     <access_arguments>edit own volunteer projects</access_arguments>
      <is_public>1</is_public>
   </item>
   <item>
@@ -56,8 +57,9 @@
     <path>civicrm/volunteer/commendation</path>
     <page_callback>CRM_Volunteer_Form_Commendation</page_callback>
     <title>Volunteer Commendation</title>
-    <!-- Access is managed in the preprocessor -->
-    <access_callback>1</access_callback>
+    <!-- Access is further restricted in the preprocessor -->
+    <access_callback>CRM_Volunteer_Permission::check</access_callback>
+    <access_arguments>edit own volunteer projects</access_arguments>
     <is_public>true</is_public>
   </item>
   <item>
@@ -96,8 +98,9 @@
     <path>civicrm/volunteer/roster</path>
     <page_callback>CRM_Volunteer_Page_Roster</page_callback>
     <title>Roster</title>
-    <!-- Access is managed in CRM_Volunteer_BAO_Project::retrieve() -->
-    <access_callback>1</access_callback>
+    <!-- Access is further restricted in CRM_Volunteer_BAO_Project::retrieve() -->
+    <access_callback>CRM_Volunteer_Permission::check</access_callback>
+    <access_arguments>edit own volunteer projects</access_arguments>
     <is_public>true</is_public>
   </item>
 </menu>

--- a/xml/Menu/Volunteer.xml
+++ b/xml/Menu/Volunteer.xml
@@ -6,7 +6,7 @@
      <title>Batch Data Entry for Logging Volunteer</title>
      <page_callback>CRM_Volunteer_Form_Log</page_callback>
      <path_arguments>action=add</path_arguments>
-     <access_arguments>access CiviEvent,edit all events</access_arguments>
+     <access_arguments>edit own volunteer projects</access_arguments>
      <component>CiviEvent</component>
   </item>
   <item>

--- a/xml/Menu/Volunteer.xml
+++ b/xml/Menu/Volunteer.xml
@@ -6,8 +6,9 @@
      <title>Batch Data Entry for Logging Volunteer</title>
      <page_callback>CRM_Volunteer_Form_Log</page_callback>
      <path_arguments>action=add</path_arguments>
-     <access_arguments>edit own volunteer projects</access_arguments>
-     <component>CiviEvent</component>
+     <!-- Access is managed in the preprocessor -->
+     <access_callback>1</access_callback>
+     <is_public>1</is_public>
   </item>
   <item>
      <path>civicrm/volunteer/need</path>
@@ -39,7 +40,6 @@
     <title>Volunteer Signup</title>
     <!-- For VOL-71, we move access control into the preprocessor -->
     <access_callback>1</access_callback>
-    <!-- <access_arguments>register to volunteer</access_arguments> -->
     <is_public>true</is_public>
   </item>
   <item>
@@ -56,7 +56,9 @@
     <path>civicrm/volunteer/commendation</path>
     <page_callback>CRM_Volunteer_Form_Commendation</page_callback>
     <title>Volunteer Commendation</title>
-    <access_arguments>access CiviCRM</access_arguments>
+    <!-- Access is managed in the preprocessor -->
+    <access_callback>1</access_callback>
+    <is_public>true</is_public>
   </item>
   <item>
     <path>civicrm/volunteer/manage/includeprofile</path>
@@ -94,6 +96,8 @@
     <path>civicrm/volunteer/roster</path>
     <page_callback>CRM_Volunteer_Page_Roster</page_callback>
     <title>Roster</title>
-    <access_arguments>access CiviCRM</access_arguments>
+    <!-- Access is managed in CRM_Volunteer_BAO_Project::retrieve() -->
+    <access_callback>1</access_callback>
+    <is_public>true</is_public>
   </item>
 </menu>

--- a/xml/Menu/Volunteer.xml
+++ b/xml/Menu/Volunteer.xml
@@ -39,8 +39,8 @@
     <path>civicrm/volunteer/signup</path>
     <page_callback>CRM_Volunteer_Form_VolunteerSignUp</page_callback>
     <title>Volunteer Signup</title>
-    <!-- For VOL-71, we move access control into the preprocessor -->
-    <access_callback>1</access_callback>
+    <access_callback>CRM_Volunteer_Permission::check</access_callback>
+    <access_arguments>register to volunteer</access_arguments>
     <is_public>true</is_public>
   </item>
   <item>


### PR DESCRIPTION
Could @TobiasLounsbury or @ginkgomzd review this, please?

Thinking about this some more, I wonder if I didn't go far enough. Perhaps we should skip checking perms at the menu entry level altogether and do like we do for [the public sign up form](https://github.com/civicrm/org.civicrm.volunteer/blob/v4.6-2.0.beta2/CRM/Volunteer/Form/VolunteerSignUp.php#L132-L138).

Benefits:
* We can use CRM_Volunteer_Permission::checkProjectPerms() to ensure the user has permission to access this particular log.
* Consistency with regard to how we deal with Joomla instances' poor handling of extension-based permissions.

Quack, quack.