### PR TITLE
Revert "VOL-208: Added checks to make sure Country.get API does not fail."

### DIFF
--- a/api/v3/VolunteerUtil.php
+++ b/api/v3/VolunteerUtil.php
@@ -296,28 +296,18 @@ function civicrm_api3_volunteer_util_getcountries($params) {
     "sequential" => 1,
   ));
 
-  $countryLimit = $settings['values'][0]['countryLimit'];
-  $defaultContactCountry = $settings['values'][0]['defaultContactCountry'];
-  if (empty($countryLimit) && !empty($defaultContactCountry)) {
-    $countryLimit = array($defaultContactCountry);
-  }
+  $countries = civicrm_api3('Country', 'get', array(
+    "id" => array(
+      "IN" => $settings['values'][0]['countryLimit'],
+    ),
+    "options" => array("limit" => 0),
+  ));
 
-  if (is_array($countryLimit) && !empty($countryLimit)) {
-    $countries = civicrm_api3('Country', 'get', array(
-      "id" => array(
-        "IN" => $countryLimit,
-      ),
-      "options" => array("limit" => 0),
-    ));
-    $results = $countries['values'];
-  } else {
-    $results = array();
-  }
-
+  $results = $countries['values'];
   foreach ($results as $k => $country) {
     // since we are wrapping CiviCRM's API, and it provides even boolean data
     // as quoted strings, we'll do the same
-    $results[$k]['is_default'] = ($country['id'] === $defaultContactCountry) ? "1" : "0";
+    $results[$k]['is_default'] = ($country['id'] === $settings['values'][0]['defaultContactCountry']) ? "1" : "0";
   }
 
   return civicrm_api3_create_success($results, "VolunteerUtil", "getcountries", $params);


### PR DESCRIPTION
Reverts civicrm/org.civicrm.volunteer#374. This code misinterprets the meaning of an empty countryLimit list, which is to be interpreted as all countries rather than no countries.

---

 * [VOL-208: Better handling when instance has no available countries](https://issues.civicrm.org/jira/browse/VOL-208)