### PR TITLE
Moved needRegistry Object creation inside Define.on:start function so…

### DIFF
--- a/js/backbone/apps/define/define_controller.js
+++ b/js/backbone/apps/define/define_controller.js
@@ -3,12 +3,6 @@ CRM.volunteerApp.module('Define', function(Define, volunteerApp, Backbone, Mario
   var layout;
   Define.startWithParent = false;
 
-  // As needs are created, updated and deleted, their IDs are added to an object.
-  // Reopening the dialog resets the data. This is intended to be
-  // an extension point; external code can listen for the volunteer:close:define event
-  // then access the list of needs indexed by event type (clean, updated, created, deleted)
-  Define.needRegistry = {"clean": [], "updated": [], "created": [], "deleted": []};
-
   // Kick everything off
   Define.addInitializer(function() {
     layout = new Define.layout();
@@ -21,6 +15,14 @@ CRM.volunteerApp.module('Define', function(Define, volunteerApp, Backbone, Mario
     volunteerApp.Entities.getNeeds({'api.volunteer_assignment.getcount': {}})
       .done(function(arrData) {
         var collectionData = volunteerApp.Entities.Needs.getScheduled(arrData);
+
+
+        // As needs are created, updated and deleted, their IDs are added to an object.
+        // Reopening the dialog resets the data. This is intended to be
+        // an extension point; external code can listen for the volunteer:close:define event
+        // then access the list of needs indexed by event type (clean, updated, created, deleted)
+        //NYCCAH-130: This needs to be reset inside the start function so it runs every time ui is recreated.
+        Define.needRegistry = {"clean": [], "updated": [], "created": [], "deleted": []};
 
         //Store the Clean Needs so 'volunteer:close:define' has reference points.
         _.each(collectionData.models, function (item) {


### PR DESCRIPTION
… that the object store is 'reset' on every ui load