### PR TITLE
Migrate settings access from BAO to API

### DIFF
--- a/CRM/Volunteer/BAO/Project.php
+++ b/CRM/Volunteer/BAO/Project.php
@@ -665,9 +665,15 @@ class CRM_Volunteer_BAO_Project extends CRM_Volunteer_DAO_Project {
   public static function composeDefaultSettingsArray() {
     $defaults = array();
 
-    $defaults['is_active'] = CRM_Core_BAO_Setting::getItem("org.civicrm.volunteer", "volunteer_project_default_is_active");
-    $defaults['campaign_id'] = CRM_Core_BAO_Setting::getItem("org.civicrm.volunteer", "volunteer_project_default_campaign");
-    $defaults['loc_block_id'] = CRM_Core_BAO_Setting::getItem("org.civicrm.volunteer", "volunteer_project_default_locblock");
+    $defaults['is_active'] = civicrm_api3('Setting', 'getvalue', array(
+      'name' => 'volunteer_project_default_is_active',
+    ));
+    $defaults['campaign_id'] = civicrm_api3('Setting', 'getvalue', array(
+      'name' => 'volunteer_project_default_campaign',
+    ));
+    $defaults['loc_block_id'] = civicrm_api3('Setting', 'getvalue', array(
+      'name' => 'volunteer_project_default_locblock',
+    ));
 
     $coreDefaultProfile = array(
       "is_active" => "1",
@@ -682,7 +688,9 @@ class CRM_Volunteer_BAO_Project extends CRM_Volunteer_DAO_Project {
     );
 
     $profiles = array();
-    $profileByType = CRM_Core_BAO_Setting::getItem("org.civicrm.volunteer", "volunteer_project_default_profiles");
+    $profileByType = civicrm_api3('Setting', 'getvalue', array(
+      'name' => 'volunteer_project_default_profiles',
+    ));
 
     foreach($profileByType as $audience => $profileForType) {
       foreach ($profileForType as $profileId) {

--- a/CRM/Volunteer/Form/Settings.php
+++ b/CRM/Volunteer/Form/Settings.php
@@ -11,6 +11,13 @@ class CRM_Volunteer_Form_Settings extends CRM_Core_Form {
 
   protected $_fieldDescriptions = array();
   protected $_helpIcons = array();
+
+  /**
+   * All settings, as fetched via API, keyed by setting name.
+   *
+   * @var array
+   */
+  protected $_settings = array();
   protected $_settingsMetadata = array();
 
   function preProcess() {
@@ -18,6 +25,9 @@ class CRM_Volunteer_Form_Settings extends CRM_Core_Form {
 
     $result = civicrm_api3('Setting', 'getfields');
     $this->_settingsMetadata = ($result['count'] > 0) ? $result['values'] : array();
+
+    $setting = civicrm_api3('Setting', 'get');
+    $this->_settings = $setting['values'][1];
   }
 
   function buildQuickForm() {
@@ -161,19 +171,19 @@ class CRM_Volunteer_Form_Settings extends CRM_Core_Form {
   function setDefaultValues() {
     $defaults = array();
 
-    $defaults['volunteer_project_default_is_active'] = CRM_Core_BAO_Setting::getItem("org.civicrm.volunteer", "volunteer_project_default_is_active");
-    $defaults['volunteer_project_default_campaign'] = CRM_Core_BAO_Setting::getItem("org.civicrm.volunteer", "volunteer_project_default_campaign");
-    $defaults['volunteer_project_default_locblock'] = CRM_Core_BAO_Setting::getItem("org.civicrm.volunteer", "volunteer_project_default_locblock");
+    $defaults['volunteer_project_default_is_active'] = CRM_Utils_Array::value('volunteer_project_default_is_active', $this->_settings);
+    $defaults['volunteer_project_default_campaign'] = CRM_Utils_Array::value('volunteer_project_default_campaign', $this->_settings);
+    $defaults['volunteer_project_default_locblock'] = CRM_Utils_Array::value('volunteer_project_default_locblock', $this->_settings);
 
     //Break the profiles out into their own fields
-    $profiles = CRM_Core_BAO_Setting::getItem("org.civicrm.volunteer", "volunteer_project_default_profiles");
+    $profiles = CRM_Utils_Array::value('volunteer_project_default_profiles', $this->_settings);
     foreach(CRM_Volunteer_BAO_Project::getProjectProfileAudienceTypes() as $audience) {
       $defaults["volunteer_project_default_profiles_" . $audience['type']] = CRM_Utils_Array::value($audience['type'], $profiles, array());
     }
 
     //General Settings
-    $defaults['volunteer_general_campaign_filter_type'] = CRM_Core_BAO_Setting::getItem("org.civicrm.volunteer", "volunteer_general_campaign_filter_type");
-    $defaults['volunteer_general_campaign_filter_list'] = CRM_Core_BAO_Setting::getItem("org.civicrm.volunteer", "volunteer_general_campaign_filter_list");
+    $defaults['volunteer_general_campaign_filter_type'] = CRM_Utils_Array::value('volunteer_general_campaign_filter_type', $this->_settings);
+    $defaults['volunteer_general_campaign_filter_list'] = CRM_Utils_Array::value('volunteer_general_campaign_filter_list', $this->_settings);
 
     return $defaults;
   }
@@ -200,22 +210,33 @@ class CRM_Volunteer_Form_Settings extends CRM_Core_Form {
       $profiles[$audience['type']] = CRM_Utils_Array::value('volunteer_project_default_profiles_' . $audience['type'], $values);
     }
 
-    CRM_Core_BAO_Setting::setItem(
-      $profiles,
-      "org.civicrm.volunteer",
-      "volunteer_project_default_profiles"
-    );
+    civicrm_api3('Setting', 'create', array(
+      "volunteer_project_default_profiles" => $profiles,
+    ));
 
-    CRM_Core_BAO_Setting::setItem(CRM_Utils_Array::value('volunteer_project_default_campaign', $values),"org.civicrm.volunteer", "volunteer_project_default_campaign");
-    CRM_Core_BAO_Setting::setItem(CRM_Utils_Array::value('volunteer_project_default_locblock', $values),"org.civicrm.volunteer", "volunteer_project_default_locblock");
-    CRM_Core_BAO_Setting::setItem(CRM_Utils_Array::value('volunteer_project_default_is_active', $values, 0), "org.civicrm.volunteer", "volunteer_project_default_is_active");
+    civicrm_api3('Setting', 'create', array(
+      "volunteer_project_default_campaign" => CRM_Utils_Array::value('volunteer_project_default_campaign', $values)
+    ));
+    civicrm_api3('Setting', 'create', array(
+      "volunteer_project_default_locblock" => CRM_Utils_Array::value('volunteer_project_default_locblock', $values)
+    ));
 
-    //Todo: Create Composit data structure like we do for profiles
-    CRM_Core_BAO_Setting::setItem(CRM_Utils_Array::value('volunteer_project_default_contacts', $values),"org.civicrm.volunteer", "volunteer_project_default_contacts");
+    civicrm_api3('Setting', 'create', array(
+      "volunteer_project_default_is_active" => CRM_Utils_Array::value('volunteer_project_default_is_active', $values, 0)
+    ));
+
+    // Todo: Create Composite data structure like we do for profiles
+    civicrm_api3('Setting', 'create', array(
+      "volunteer_project_default_contacts" => CRM_Utils_Array::value('volunteer_project_default_contacts', $values)
+    ));
 
     //Whitelist/Blacklist settings
-    CRM_Core_BAO_Setting::setItem(CRM_Utils_Array::value('volunteer_general_campaign_filter_type', $values), "org.civicrm.volunteer", "volunteer_general_campaign_filter_type");
-    CRM_Core_BAO_Setting::setItem(CRM_Utils_Array::value('volunteer_general_campaign_filter_list', $values, 0), "org.civicrm.volunteer", "volunteer_general_campaign_filter_list");
+    civicrm_api3('Setting', 'create', array(
+      "volunteer_general_campaign_filter_type" => CRM_Utils_Array::value('volunteer_general_campaign_filter_type', $values)
+    ));
+    civicrm_api3('Setting', 'create', array(
+      "volunteer_general_campaign_filter_list" => CRM_Utils_Array::value('volunteer_general_campaign_filter_list', $values, 0)
+    ));
 
     CRM_Core_Session::setStatus(ts("Changes Saved", array('domain' => 'org.civicrm.volunteer')), "Saved", "success");
     parent::postProcess();

--- a/CRM/Volunteer/Form/Settings.php
+++ b/CRM/Volunteer/Form/Settings.php
@@ -239,7 +239,7 @@ class CRM_Volunteer_Form_Settings extends CRM_Core_Form {
       "volunteer_general_campaign_filter_type" => CRM_Utils_Array::value('volunteer_general_campaign_filter_type', $values)
     ));
     civicrm_api3('Setting', 'create', array(
-      "volunteer_general_campaign_filter_list" => CRM_Utils_Array::value('volunteer_general_campaign_filter_list', $values, 0)
+      "volunteer_general_campaign_filter_list" => CRM_Utils_Array::value('volunteer_general_campaign_filter_list', $values, array())
     ));
 
     CRM_Core_Session::setStatus(ts("Changes Saved", array('domain' => 'org.civicrm.volunteer')), "Saved", "success");

--- a/CRM/Volunteer/Form/Settings.php
+++ b/CRM/Volunteer/Form/Settings.php
@@ -26,8 +26,12 @@ class CRM_Volunteer_Form_Settings extends CRM_Core_Form {
     $result = civicrm_api3('Setting', 'getfields');
     $this->_settingsMetadata = ($result['count'] > 0) ? $result['values'] : array();
 
+    $currentDomainId = civicrm_api3('Domain', 'getvalue', array(
+      'return' => array("id"),
+      'current_domain' => 1,
+    ));
     $setting = civicrm_api3('Setting', 'get');
-    $this->_settings = $setting['values'][1];
+    $this->_settings = $setting['values'][$currentDomainId];
   }
 
   function buildQuickForm() {

--- a/api/v3/VolunteerUtil.php
+++ b/api/v3/VolunteerUtil.php
@@ -248,8 +248,12 @@ function civicrm_api3_volunteer_util_getbeneficiaries($params) {
  * @return array
  */
 function civicrm_api3_volunteer_util_getcampaigns($params) {
-  $filterType = CRM_Core_BAO_Setting::getItem("org.civicrm.volunteer", "volunteer_general_campaign_filter_type");
-  $filterList = CRM_Core_BAO_Setting::getItem("org.civicrm.volunteer", "volunteer_general_campaign_filter_list");
+  $filterType = civicrm_api3('Setting', 'getvalue', array(
+    'name' => 'volunteer_general_campaign_filter_type',
+  ));
+  $filterList = civicrm_api3('Setting', 'getvalue', array(
+    'name' => 'volunteer_general_campaign_filter_list',
+  ));
 
   $campaignParams = array(
     "options" => array("limit" => 0),

--- a/settings/volunteer.setting.php
+++ b/settings/volunteer.setting.php
@@ -20,10 +20,10 @@ return array(
     'name' => 'volunteer_project_default_profiles',
     'type' => 'Array',
     'default' => array(
-      "primary" => civicrm_api3('UFGroup', 'getvalue', array(
+      "primary" => array(civicrm_api3('UFGroup', 'getvalue', array(
         "name" => "volunteer_sign_up",
         "return" => "id"
-      ))),
+      )))),
     'add' => '4.5',
     'is_domain' => 1,
     'is_contact' => 0,

--- a/volunteer.slider.php
+++ b/volunteer.slider.php
@@ -124,5 +124,8 @@ function _volunteer_update_slider_fields(array $params) {
   }
 
   sort($widgetized_fields);
-  CRM_Core_BAO_Setting::setItem($widgetized_fields, 'CiviVolunteer Configurations', 'slider_widget_fields');
+  civicrm_api3('Setting', 'create', array(
+    'slider_widget_fields' => $widgetized_fields,
+  ));
+
 }


### PR DESCRIPTION
This PR also includes a fix for a minor bug in which the default value for a setting couldn't be read because it was formatted improperly. It's minor because:
- the setting in question still hasn't been part of a formal release
- user-provided values for the setting were being formatted properly and could be retrieved and used as expected