### PR TITLE
VOL-210 Simplify action buttons for the Edit Project form.

### DIFF
--- a/ang/volunteer.css
+++ b/ang/volunteer.css
@@ -154,3 +154,7 @@ span.crm-button-text {
   background: rgba(255, 255, 0, 0.1);
 }
 
+.crm-vol-project-submit-buttons .crm-vol-save-done {
+  display: none !important;;
+}
+

--- a/ang/volunteer/Project.html
+++ b/ang/volunteer/Project.html
@@ -172,7 +172,7 @@
     <div class="crm-submit-buttons crm-vol-project-submit-buttons">
       <span class="crm-button crm-icon-button crm-vol-button crm-vol-save-next crm-vol-project-save-next" ng-click="saveAndNext()">
         <span class="crm-button-icon ui-icon-triangle-1-e"> </span>
-        <span class="crm-button-text">{{saveAndNextLabel}}</span>
+        <span class="crm-button-text">{{ts('Add Opportunities')}}</span>
       </span>
       <span ng-show="formContext === 'standAlone'" class="crm-button crm-icon-button crm-vol-button crm-vol-save-done crm-vol-project-save-done" ng-click="saveAndDone()">
         <span class="crm-button-icon ui-icon-circle-check"> </span>


### PR DESCRIPTION
Rename 'Save and Next' to 'Add Opportunities'.  Hide the 'Done' button.
If a specific client wants the button back, their custom CSS can show
it.