### PR TITLE
VOL-248: Display custom project relationship fields on the project create/edit screen.

### DIFF
--- a/ang/volunteer/Project.js
+++ b/ang/volunteer/Project.js
@@ -112,6 +112,11 @@
       });
     }
 
+    // start with the assumption that all relationship fields will be displayed
+    _.each(supporting_data.values.relationship_types, function(v, k) {
+      showRelationshipType[v.value] = true;
+    });
+
     // flatten the data a bit to make it easier to work with in the template
     _.each(volRelData, function (contacts, relTypeId) {
       relationships[relTypeId] = [];


### PR DESCRIPTION
* [VOL-248: Regression: Custom project relationship fields are not displayed on project create\/edit screen](https://issues.civicrm.org/jira/browse/VOL-248)