### PR TITLE
More work on VOL-249.

### DIFF
--- a/CRM/Volunteer/Form/VolunteerSignUp.php
+++ b/CRM/Volunteer/Form/VolunteerSignUp.php
@@ -374,7 +374,8 @@ class CRM_Volunteer_Form_VolunteerSignUp extends CRM_Core_Form {
 
     $profileFields = $this->getProfileFields($this->getPrimaryVolunteerProfileIDs());
     $profileFieldsByType = array_reduce($profileFields, array($this, 'reduceByType'), array());
-    $activityValues = array_intersect_key($values, $profileFieldsByType['Activity']);
+    $activityFields = CRM_Utils_Array::value('Activity', $profileFieldsByType, array());
+    $activityValues = array_intersect_key($values, $activityFields);
     $contactValues = array_diff_key($values, $activityValues);
 
     $this->_primary_volunteer_id = $this->processContactProfileData($contactValues, $profileFields, $cid);


### PR DESCRIPTION
Fixed implicit assumption that there would *always* be Activity fields in the sign-up profiles.

---

 * [VOL-249: Regression: Activity fields added via profile are not processed on volunteer registration](https://issues.civicrm.org/jira/browse/VOL-249)