### PR TITLE
CRM-19498 Fix PHP warning in Volunteer Report

### DIFF
--- a/CRM/Volunteer/Form/VolunteerReport.php
+++ b/CRM/Volunteer/Form/VolunteerReport.php
@@ -212,6 +212,7 @@ class CRM_Volunteer_Form_VolunteerReport extends CRM_Report_Form {
           ),
           'status_id' => array(
             'title' => ts('Activity Status', array('domain' => 'org.civicrm.volunteer')),
+            'type' => CRM_Utils_Type::T_STRING,
             'operatorType' => CRM_Report_Form::OP_MULTISELECT,
             'options' => CRM_Core_PseudoConstant::activityStatus(),
           ),
@@ -685,4 +686,3 @@ class CRM_Volunteer_Form_VolunteerReport extends CRM_Report_Form {
     }
   }
 }
-


### PR DESCRIPTION
The Volunteer report displays a PHP warning:

> User warning: Type is not defined for field status_id in CRM_Report_Form->whereClause() (line 1830 of /home/wmortada/buildkit/build/dmaster/sites/all/modules/civicrm/CRM/Report/Form.php).

I've fixed this by adding a type for the status_id field.

---

 * [CRM-19498: PHP notice on Volunteer Report](https://issues.civicrm.org/jira/browse/CRM-19498)