### PR TITLE
VOL-202: Bugfixes for newly implemented updates.

### DIFF
--- a/CRM/Volunteer/BAO/Project.php
+++ b/CRM/Volunteer/BAO/Project.php
@@ -187,10 +187,10 @@ class CRM_Volunteer_BAO_Project extends CRM_Volunteer_DAO_Project {
     if (!array_key_exists('loc_block_id', $params)) {
       $params['loc_block_id'] = $defaults['loc_block_id'];
     }
-    if (!array_key_exists('profiles', $params)) {
+    if (!array_key_exists('profiles', $params) || !CRM_Volunteer_Permission::check('edit volunteer registration profiles')) {
       $params['profiles'] = $defaults['profiles'];
     }
-    if (!array_key_exists('project_contacts', $params)) {
+    if (!array_key_exists('project_contacts', $params) || !CRM_Volunteer_Permission::check('edit volunteer project relationships')) {
       $params['project_contacts'] = $defaults['relationships'];
     }
 

--- a/CRM/Volunteer/BAO/Project.php
+++ b/CRM/Volunteer/BAO/Project.php
@@ -299,6 +299,11 @@ class CRM_Volunteer_BAO_Project extends CRM_Volunteer_DAO_Project {
         if (is_array($profile['module_data'])) {
           $profile['module_data'] = json_encode($profile['module_data']);
         }
+
+        // Since we delete then recreate the ufjoins, drop the ID from the params
+        // or else CiviCRM tries to update a nonexistent record and fails silently
+        unset($profile['id']);
+
         civicrm_api3('UFJoin', 'create', $profile);
       }
     }

--- a/CRM/Volunteer/BAO/Project.php
+++ b/CRM/Volunteer/BAO/Project.php
@@ -250,10 +250,22 @@ class CRM_Volunteer_BAO_Project extends CRM_Volunteer_DAO_Project {
 
     $project->save();
 
+    // Prevent updates for unpermissioned users.
+    $hasEditVPC = CRM_Volunteer_Permission::check('edit volunteer project relationships');
+    $hasEditProfiles = CRM_Volunteer_Permission::check('edit volunteer registration profiles');
+    if ($op === CRM_Core_Action::UPDATE) {
+      if (!$hasEditVPC) {
+        unset($params['project_contacts']);
+      }
+      if (!$hasEditProfiles) {
+        unset($params['profiles']);
+      }
+    }
+
     // If updating, treat profile and project contact relationship params as
     // replacement data. Start by deleting existing relationships.
-    $updateVPC = ($op === CRM_Core_Action::UPDATE) && !empty($params['project_contacts']) && CRM_Volunteer_Permission::check('edit volunteer project relationships');
-    $updateProfiles = ($op === CRM_Core_Action::UPDATE) && !empty($params['profiles']) && CRM_Volunteer_Permission::check('edit volunteer registration profiles');
+    $updateVPC = ($op === CRM_Core_Action::UPDATE) && !empty($params['project_contacts']) && $hasEditVPC;
+    $updateProfiles = ($op === CRM_Core_Action::UPDATE) && !empty($params['profiles']) && $hasEditProfiles;
     if ($updateVPC) {
       civicrm_api3('VolunteerProjectContact', 'get', array(
         'options' => array('limit' => 0),

--- a/CRM/Volunteer/BAO/Project.php
+++ b/CRM/Volunteer/BAO/Project.php
@@ -269,7 +269,12 @@ class CRM_Volunteer_BAO_Project extends CRM_Volunteer_DAO_Project {
         // CRM-17222: For compatibility with CiviCRM 4.6, we use our custom API.
         // When support for 4.6 is dropped, we can use core's api.UFJoin.delete.
         // 'api.UFJoin.delete' => array(),
-        'api.VolunteerProject.removeprofile' => array(),
+        'api.VolunteerProject.removeprofile' => array(
+          // For some reason, the ID param implicit in chained API calls is not
+          // getting passed, so we specify it manually. Since the API is
+          // deprecated, this short-term solution is good enough.
+          'id' => '$value.id',
+        ),
       ));
     }
 

--- a/CRM/Volunteer/Permission.php
+++ b/CRM/Volunteer/Permission.php
@@ -61,12 +61,14 @@ class CRM_Volunteer_Permission extends CRM_Core_Permission {
    */
   public static function check($permissions) {
     $permissions = (array) $permissions;
-    $isModulePermissionSupported = CRM_Core_Config::singleton()->userPermissionClass->isModulePermissionSupported();
 
-    array_walk_recursive($permissions, function(&$v, $k) use ($isModulePermissionSupported) {
+    $permClass = CRM_Core_Config::singleton()->userPermissionClass;
+    $skipCheck = !$permClass->isModulePermissionSupported() && !is_a($permClass, 'CRM_Core_Permission_UnitTests');
+
+    array_walk_recursive($permissions, function(&$v, $k) use ($skipCheck) {
       // For VOL-71, if this is a permissions-challenged Joomla instance, don't
       // enforce CiviVolunteer-defined permissions.
-      if (!$isModulePermissionSupported) {
+      if ($skipCheck) {
         if (array_key_exists($v, CRM_Volunteer_Permission::getVolunteerPermissions())) {
           $v = CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION;
         }

--- a/ang/volunteer/Project.js
+++ b/ang/volunteer/Project.js
@@ -161,13 +161,14 @@
     // If the user doesn't have this permission, there is no sense in keeping
     // profile data on the model or submitting it to the API.
     if (!CRM.checkPerm('edit volunteer registration profiles')) {
-      project.profiles = [];
+      delete project.profiles;
+    } else {
+      $.each(project.profiles, function (key, data) {
+        if(data.module_data && typeof(data.module_data) === "string") {
+          data.module_data = JSON.parse(data.module_data);
+        }
+      });
     }
-    $.each(project.profiles, function (key, data) {
-      if(data.module_data && typeof(data.module_data) === "string") {
-        data.module_data = JSON.parse(data.module_data);
-      }
-    });
 
     $scope.campaigns = campaigns;
     $scope.relationship_types = supporting_data.values.relationship_types;

--- a/api/v3/VolunteerProjectContact.php
+++ b/api/v3/VolunteerProjectContact.php
@@ -46,7 +46,7 @@
  * @access public
  */
 function civicrm_api3_volunteer_project_contact_create($params) {
-  if (!$params['check_permissions'] || CRM_Volunteer_Permission::checkProjectPerms(CRM_Core_Action::UPDATE, $params['project_id'])) {
+  if (empty($params['check_permissions']) || CRM_Volunteer_Permission::checkProjectPerms(CRM_Core_Action::UPDATE, $params['project_id'])) {
     return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
   } else {
     return civicrm_api3_create_error(ts('You do not have permission to modify contacts for this project'));
@@ -131,7 +131,7 @@ function civicrm_api3_volunteer_project_contact_get($params) {
  */
 function civicrm_api3_volunteer_project_contact_delete($params) {
   $projectId = CRM_Core_DAO::getFieldValue("CRM_Volunteer_DAO_ProjectContact", $params['id'], "project_id");
-  if (!$params['check_permissions'] || CRM_Volunteer_Permission::checkProjectPerms(CRM_Core_Action::UPDATE, $projectId)) {
+  if (empty($params['check_permissions']) || CRM_Volunteer_Permission::checkProjectPerms(CRM_Core_Action::UPDATE, $projectId)) {
     return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
   } else {
     return civicrm_api3_create_error(ts('You do not have permission to modify contacts for this project'));

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" syntaxCheck="false" bootstrap="tests/phpunit/bootstrap.php">
+  <testsuites>
+    <testsuite name="My Test Suite">
+      <directory>./tests/phpunit</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">./</directory>
+    </whitelist>
+  </filter>
+  <listeners>
+    <listener class="Civi\Test\CiviTestListener">
+      <arguments/>
+    </listener>
+  </listeners>
+</phpunit>

--- a/tests/phpunit/VolunteerTestAbstract.php
+++ b/tests/phpunit/VolunteerTestAbstract.php
@@ -1,11 +1,13 @@
 <?php
 
-require_once 'CiviTest/CiviUnitTestCase.php';
+use Civi\Test\HeadlessInterface;
+use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
 
 /**
  * Abstract class for Volunteer tests
  */
-abstract class VolunteerTestAbstract extends CiviUnitTestCase {
+abstract class VolunteerTestAbstract extends \PHPUnit_Framework_TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
 
   /**
    * Ensure that, if the database is repopulated, CiviVolunteer's install
@@ -49,4 +51,13 @@ abstract class VolunteerTestAbstract extends CiviUnitTestCase {
 
     return TRUE;
   }
+
+  public function setUpHeadless() {
+    // Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().
+    // See: https://github.com/civicrm/org.civicrm.testapalooza/blob/master/civi-test.md
+    return \Civi\Test::headless()
+            ->installMe(__DIR__)
+            ->apply();
+  }
+
 }

--- a/tests/phpunit/VolunteerTestAbstract.php
+++ b/tests/phpunit/VolunteerTestAbstract.php
@@ -10,54 +10,66 @@ use Civi\Test\TransactionalInterface;
 abstract class VolunteerTestAbstract extends \PHPUnit_Framework_TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
 
   /**
-   * Ensure that, if the database is repopulated, CiviVolunteer's install
-   * operations are run, adding custom option group, activity fields, etc. to
-   * the testing DB. NOTE: Installation/alteration of tables not managed by
-   * core (e.g., civicrm_volunteer_project) should not be reproduced here.
+   * The ID of a contact mocked as the acting user.
    *
-   * @param type $perClass
-   * @param type $object
-   * @return boolean
+   * Some volunteer code checks to see who the logged in user is -- e.g., to
+   * fetch related contacts or owned projects. Tests will fail if
+   * CRM_Core_Session::getLoggedInContactID() doesn't return a valid ID, so we
+   * want to make sure to mock this.
+   *
+   * NOTE: To access this value, use getter getMockedContactId() instead of
+   * accessing the property directly.
+   *
+   * NOTE: We expect that permissions management will be an unrelated process to
+   * this mocking.
+   *
+   * @var int
    */
-  protected static function _populateDB($perClass = FALSE, &$object = NULL) {
-    if (!parent::_populateDB($perClass, $object)) {
-      return FALSE;
-    }
-
-    // Code adapted from CRM_Volunteer_Upgrader::install().
-    $upgrader = new CRM_Volunteer_Upgrader('org.civicrm.volunteer', dirname(__FILE__) . '/../../');
-
-    $activityTypeId = $upgrader->createActivityType(CRM_Volunteer_BAO_Assignment::CUSTOM_ACTIVITY_TYPE);
-    $smarty = CRM_Core_Smarty::singleton();
-    $smarty->assign('volunteer_custom_activity_type_name', CRM_Volunteer_BAO_Assignment::CUSTOM_ACTIVITY_TYPE);
-    $smarty->assign('volunteer_custom_group_name', CRM_Volunteer_BAO_Assignment::CUSTOM_GROUP_NAME);
-    $smarty->assign('volunteer_custom_option_group_name', CRM_Volunteer_BAO_Assignment::ROLE_OPTION_GROUP);
-    $smarty->assign('volunteer_activity_type_id', $activityTypeId);
-
-    $customIDs = $upgrader->findCustomGroupValueIDs();
-    $smarty->assign('customIDs', $customIDs);
-
-    $upgrader->executeCustomDataTemplateFile('volunteer-customdata.xml.tpl');
-
-    $upgrader->createVolunteerActivityStatus();
-
-    $upgrader->createVolunteerContactType();
-    $volContactTypeCustomGroupID = $upgrader->createVolunteerContactCustomGroup();
-    $upgrader->createVolunteerContactCustomFields($volContactTypeCustomGroupID);
-
-    $upgrader->installCommendationActivityType();
-
-    $upgrader->installProjectRelationships();
-
-    return TRUE;
-  }
+  protected $mockedContactId;
+  protected $mockedContactParams = array(
+    'contact_type' => 'Individual',
+    'first_name' => 'Logged',
+    'last_name' => 'In',
+  );
 
   public function setUpHeadless() {
     // Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().
     // See: https://github.com/civicrm/org.civicrm.testapalooza/blob/master/civi-test.md
     return \Civi\Test::headless()
             ->installMe(__DIR__)
+            ->callback(function() {
+              $mockedContact = \CRM_Core_DAO::createTestObject('CRM_Contact_DAO_Contact', $this->mockedContactParams);
+              $this->mockedContactId = $mockedContact->id;
+            }, 'mockContact')
+            ->callback(function() {
+              // This is a hack that we hope to remove once we figure out why most settings
+              // are nonexistent following installation.
+              $params = array();
+              $extSettings = include(__DIR__ . '/../../settings/volunteer.setting.php');
+              foreach ($extSettings as $setting) {
+                $params[$setting['name']] = $setting['default'];
+              }
+              CRM_Core_BAO_Setting::setItems($params);
+            }, 'importSettings')
             ->apply();
+  }
+
+  function setUp() {
+    // Apparently actions performed in setUpHeadless take place in a different
+    // session, so our mocked contact's ID needs to be added into the session
+    // before each test.
+    \CRM_Core_Session::singleton()->set('userID', $this->getMockedContactId());
+  }
+
+  function getMockedContactId() {
+    if (empty($this->mockedContactId)) {
+      $params = $this->mockedContactParams;
+      $params['return'] = 'id';
+      // cast as int for compatibility with \CRM_Core_DAO::createTestObject
+      $this->mockedContactId = (int) civicrm_api3('Contact', 'getvalue', $params);
+    }
+
+    return $this->mockedContactId;
   }
 
 }

--- a/tests/phpunit/api/v3/VolunteerProjectTest.php
+++ b/tests/phpunit/api/v3/VolunteerProjectTest.php
@@ -1,17 +1,13 @@
 <?php
 
+require_once __DIR__ . '/../../VolunteerTestAbstract.php';
+
 /**
  * Test class for Volunteer Project API - volunteer_project
+ *
+ * @group headless
  */
 class api_v3_VolunteerProjectTest extends VolunteerTestAbstract {
-
-  /**
-   * Clean table civicrm_volunteer_project
-   */
-  function setUp() {
-    $this->quickCleanup(array('civicrm_volunteer_project'));
-    parent::setUp();
-  }
 
   /**
    * Test simple create via API
@@ -24,8 +20,16 @@ class api_v3_VolunteerProjectTest extends VolunteerTestAbstract {
       'title' => 'Unit Testing for CiviVolunteer (How Meta)',
     );
 
-    $this->callAPIAndDocument('VolunteerProject', 'create', $params, __FUNCTION__, __FILE__);
+    $api = civicrm_api3('VolunteerProject', 'create', $params);
+    $this->assertTrue(is_numeric($api['id']));
+    $this->assertTrue($api['id'] > 0);
+
+    $project = new CRM_Volunteer_BAO_Project();
+    $project->copyValues($params);
+    $this->assertEquals(1, $project->find());
   }
+
+  // TESTS BELOW HAVE NOT BEEN PORTED TO PHPUnit_Framework_TestCase CLASS YET
 
   /**
    * Tests the project_contacts parameter to the create API, i.e., tests the
@@ -79,4 +83,5 @@ class api_v3_VolunteerProjectTest extends VolunteerTestAbstract {
 
     $this->callAPIAndDocument('VolunteerProject', 'get', array('id' => $project->id), __FUNCTION__, __FILE__);
   }
+
 }

--- a/tests/phpunit/api/v3/VolunteerProjectTest.php
+++ b/tests/phpunit/api/v3/VolunteerProjectTest.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once 'VolunteerTestAbstract.php';
-
 /**
  * Test class for Volunteer Project API - volunteer_project
  */

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,0 +1,49 @@
+<?php
+
+ini_set('memory_limit', '2G');
+ini_set('safe_mode', 0);
+eval(cv('php:boot --level=classloader', 'phpcode'));
+
+/**
+ * Call the "cv" command.
+ *
+ * @param string $cmd
+ *   The rest of the command to send.
+ * @param string $decode
+ *   Ex: 'json' or 'phpcode'.
+ * @return string
+ *   Response output (if the command executed normally).
+ * @throws \RuntimeException
+ *   If the command terminates abnormally.
+ */
+function cv($cmd, $decode = 'json') {
+  $cmd = 'cv ' . $cmd;
+  $descriptorSpec = array(0 => array("pipe", "r"), 1 => array("pipe", "w"), 2 => STDERR);
+  $oldOutput = getenv('CV_OUTPUT');
+  putenv("CV_OUTPUT=json");
+  $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
+  putenv("CV_OUTPUT=$oldOutput");
+  fclose($pipes[0]);
+  $result = stream_get_contents($pipes[1]);
+  fclose($pipes[1]);
+  if (proc_close($process) !== 0) {
+    throw new RuntimeException("Command failed ($cmd):\n$result");
+  }
+  switch ($decode) {
+    case 'raw':
+      return $result;
+
+    case 'phpcode':
+      // If the last output is /*PHPCODE*/, then we managed to complete execution.
+      if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
+        throw new \RuntimeException("Command failed ($cmd):\n$result");
+      }
+      return $result;
+
+    case 'json':
+      return json_decode($result, 1);
+
+    default:
+      throw new RuntimeException("Bad decoder format ($decode)");
+  }
+}


### PR DESCRIPTION
With these commits, the following manual user tests pass:

* create via API as admin with just a title, expect all defaults applied
* update via GUI as admin with new project contacts, expect only project contacts to change
* update via GUI as admin with new profiles, expect only profiles to change
* update via API as admin with new project contacts, expect only project contacts to change
* update via API as admin with new profiles, expect only profiles to change
* create via GUI as admin, expect defaults not to override supplied values
* create via API as coord with just a title, expect all defaults applied
* create via GUI as coord, expect project contact and profiles supplied
* update via GUI as coord, expect project contact and profiles unchanged
* update via API as coord, expect project contact and profile params to be ignored
* create via API as coord, expect project contact and profile params to be ignored, defaults instead

... where user admin has "edit volunteer project relationships" and "edit volunteer registration profiles" and user coord does not.

---

 * [VOL-202: Add Project Relationship Defaults to Defaults UI](https://issues.civicrm.org/jira/browse/VOL-202)