### PR TITLE
Fixed fatal error for PHP 5.6

### DIFF
--- a/CRM/Volunteer/Permission.php
+++ b/CRM/Volunteer/Permission.php
@@ -73,7 +73,7 @@ class CRM_Volunteer_Permission extends CRM_Core_Permission {
       }
 
       // Ensure that checks for "edit own" pass if user has "edit all."
-      if ($v === 'edit own volunteer projects' && self::check('edit all volunteer projects')) {
+      if ($v === 'edit own volunteer projects' && CRM_Volunteer_Permission::check('edit all volunteer projects')) {
         $v = CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION;
       }
     });


### PR DESCRIPTION
Adding volunteer hours results in following error message and WSOD. 
Cannot access self:: when no class scope is active