### PR TITLE
VOL-276: Path to deprecating api.VolunteerUtil.getbeneficiaries.

### DIFF
--- a/ang/volunteer/Projects.html
+++ b/ang/volunteer/Projects.html
@@ -1,4 +1,5 @@
 <div class="crm-container">
+  <!-- TODO for VOL-267: Remove beneficiaries debugging block. -->
   <div crm-ui-debug="beneficiaries"></div>
   <div crm-ui-debug="campaigns"></div>
   <div crm-ui-debug="projects"></div>
@@ -33,6 +34,7 @@
               <input crm-ui-id="volProjectSearchForm.title" ng-model="searchParams.title" />
             </div>
             <div class="crm-vol-field crm-vol-field-projects-search-beneficiaries" crm-ui-field="{name: 'volProjectSearchForm.beneficiary', title: ts('Beneficiary')}">
+              <!-- TODO for VOL-267: Replace this with an entityRef widget. -->
               <select class="big crm-form-select crm-vol-beneficiary" crm-ui-select="{placeholder: ts('Filter by Beneficiary'), allowClear:true}"
                       ng-options="key as value.display_name for (key , value) in beneficiaries" ng-model="searchParams.beneficiaries">
                 <option />

--- a/ang/volunteer/Projects.js
+++ b/ang/volunteer/Projects.js
@@ -8,6 +8,8 @@
         // If you need to look up data when opening the page, list it out
         // under "resolve".
         resolve: {
+          // TODO for VOL-276: Factor this out. api.VolunteerUtil.getbeneficiaries
+          // is deprecated in favor of api.VolunteerProjectContact.getList.
           beneficiaries: function (crmApi) {
             return crmApi('VolunteerUtil', 'getbeneficiaries').then(function(data) {
               return data.values;
@@ -56,6 +58,7 @@
     }
   );
 
+  // TODO for VOL-276: Remove reference to beneficiaries object, based on deprecated API.
   angular.module('volunteer').controller('VolunteerProjects', function ($scope, $filter, crmApi, crmStatus, crmUiHelp, projectData, $location, volunteerBackbone, beneficiaries, campaigns, $window) {
     // The ts() and hs() functions help load strings for this module.
     var ts = $scope.ts = CRM.ts('org.civicrm.volunteer');
@@ -67,6 +70,7 @@
     $scope.projects = projectData;
     $scope.batchAction = "";
     $scope.allSelected = false;
+    // TODO for VOL-276: Remove reference to beneficiaries object, based on deprecated API.
     $scope.beneficiaries = beneficiaries;
     $scope.campaigns = campaigns;
     $scope.needBase = CRM.url("civicrm/volunteer/need");
@@ -130,6 +134,9 @@
       return result;
     };
 
+    // TODO for VOL-276: Replace or obviate the need for this method. This is
+    // the blocker to removing the deprecated api.VolunteerUtil.getbeneficiaries.
+    // Other related changes are trivial.
     $scope.formatBeneficiaries = function (project) {
       var displayNames = [];
 

--- a/api/v3/VolunteerProjectContact.php
+++ b/api/v3/VolunteerProjectContact.php
@@ -147,3 +147,24 @@ function civicrm_api3_volunteer_project_contact_delete($params) {
 function _civicrm_api3_volunteer_project_contact_delete_spec(&$params) {
   $params['id']['api.required'] = 1;
 }
+
+/**
+ * Set the default getList behavior to return a list of contact IDs labeled by
+ * contact sort names.
+ *
+ * @param array $request
+ *   The parameters passed to the sub-API call (i.e., the parameters to the get
+ *   call underlying the getList call). These are passed to getList in
+ *   $params['params'].
+ * @return array
+ *   Despite the fact that $request represents a subset of the parameters passed
+ *   to getList, the return of this function is merged with the getList params
+ *   in their entirety.
+ */
+function _civicrm_api3_volunteer_project_contact_getlist_defaults(&$request) {
+  return array(
+    'id_field' => 'contact_id',
+    'label_field' => 'contact_id.sort_name',
+    'search_field' => 'contact_id.sort_name',
+  );
+}

--- a/api/v3/VolunteerUtil.php
+++ b/api/v3/VolunteerUtil.php
@@ -10,6 +10,20 @@
  */
 
 /**
+ * @deprecated api notice
+ * @return array
+ *   Array of deprecated actions
+ */
+function _civicrm_api3_volunteer_util_deprecation() {
+  return array(
+    'getbeneficiaries' => 'VolunteerUtil API "getbeneficiaries" action is '
+    . 'deprecated in favor of api.VolunteerProjectContacts.getList. Set the '
+    . '"params" parameter to array("relationship_type_id" => "volunteer_beneficiary") '
+    . 'to replace calls to api.VolunteerUtil.getbeneficiaries.',
+  );
+}
+
+/**
  * This function will return the needed pieces to load up the backbone/
  * marionette project backend from within an angular page.
  *
@@ -171,6 +185,10 @@ function civicrm_api3_volunteer_util_getsupportingdata($params) {
 
 /**
  * This method returns a list of beneficiaries
+ *
+ * @deprecated since version 2.3
+ *   api.VolunteerProjectContacts.getList serves the same purpose and is both
+ *   more efficient more versatile.
  *
  * @param array $params
  *   Not presently used.


### PR DESCRIPTION
* [VOL-276: Deprecate api.VolunteerUtil.getbeneficiaries](https://issues.civicrm.org/jira/browse/VOL-276)