### PR TITLE
VOL-284: Use entityRef widgets for activity contact filters on the volunteer report

### DIFF
--- a/CRM/Volunteer/Form/VolunteerReport.php
+++ b/CRM/Volunteer/Form/VolunteerReport.php
@@ -296,7 +296,18 @@ class CRM_Volunteer_Form_VolunteerReport extends CRM_Report_Form {
       ),
     );
 
-    // forgive me for this terrible hack
+    $this->addPhoneFields();
+
+    $this->_groupFilter = TRUE;
+    $this->_tagFilter = TRUE;
+    parent::__construct();
+  }
+
+  /**
+   * Loops through the various activity contacts and phone types and builds a
+   * column for each phone type per contact.
+   */
+  protected function addPhoneFields() {
     $phoneTypes = CRM_Core_BAO_Phone::buildOptions('phone_type_id');
     $activityRoles = array(
       'assignee' => array(
@@ -316,6 +327,7 @@ class CRM_Volunteer_Form_VolunteerReport extends CRM_Report_Form {
       ),
     );
 
+    // a table for each contact related to the activity
     foreach ($activityRoles as $roleKey => $role) {
       $table = "phone_{$roleKey}";
       $this->_columns[$table] = array(
@@ -325,6 +337,7 @@ class CRM_Volunteer_Form_VolunteerReport extends CRM_Report_Form {
         'fields' => array(),
       );
 
+      // a field for each type of phone number
       foreach ($phoneTypes as $phoneKey => $label) {
         $this->_columns[$table]['fields']["{$table}_type{$phoneKey}"] = array(
           'alias' => "{$table}_civireport_type{$phoneKey}",
@@ -333,10 +346,6 @@ class CRM_Volunteer_Form_VolunteerReport extends CRM_Report_Form {
         );
       }
     }
-
-    $this->_groupFilter = TRUE;
-    $this->_tagFilter = TRUE;
-    parent::__construct();
   }
 
   function select() {

--- a/CRM/Volunteer/Form/VolunteerReport.php
+++ b/CRM/Volunteer/Form/VolunteerReport.php
@@ -86,25 +86,34 @@ class CRM_Volunteer_Form_VolunteerReport extends CRM_Report_Form {
         ),
         'filters' => array(
           'contact_assignee' => array(
-            'name' => 'sort_name',
+            'name' => 'id',
             'alias' => 'civicrm_contact_assignee_civireport',
-            'title' => ts('Volunteer Name', array('domain' => 'org.civicrm.volunteer')),
-            'operator' => 'like',
-            'type' => CRM_Report_Form::OP_STRING,
+            'title' => ts('Volunteer (assignee contact)', array('domain' => 'org.civicrm.volunteer')),
+            'operatorType' => CRM_Report_Form::OP_ENTITYREF,
+            'type' => CRM_Utils_Type::T_INT,
+            'attributes' => array(
+              'select' => array('minimumInputLength' => 0),
+            ),
           ),
           'contact_source' => array(
-            'name' => 'sort_name',
+            'name' => 'id',
             'alias' => 'civicrm_contact_source',
-            'title' => ts('Source Contact Name', array('domain' => 'org.civicrm.volunteer')),
-            'operator' => 'like',
-            'type' => CRM_Report_Form::OP_STRING,
+            'title' => ts('Assigner (source contact)', array('domain' => 'org.civicrm.volunteer')),
+            'operatorType' => CRM_Report_Form::OP_ENTITYREF,
+            'type' => CRM_Utils_Type::T_INT,
+            'attributes' => array(
+              'select' => array('minimumInputLength' => 0),
+            ),
           ),
           'contact_target' => array(
-            'name' => 'sort_name',
+            'name' => 'id',
             'alias' => 'contact_civireport',
-            'title' => ts('Target Contact Name', array('domain' => 'org.civicrm.volunteer')),
-            'operator' => 'like',
-            'type' => CRM_Report_Form::OP_STRING,
+            'title' => ts('Beneficiary (target contact)', array('domain' => 'org.civicrm.volunteer')),
+            'operatorType' => CRM_Report_Form::OP_ENTITYREF,
+            'type' => CRM_Utils_Type::T_INT,
+            'attributes' => array(
+              'select' => array('minimumInputLength' => 0),
+            ),
           ),
           'current_user' => array(
             'name' => 'current_user',


### PR DESCRIPTION
* [VOL-284: Use entityRef widgets for activity contact filters on the volunteer report](https://issues.civicrm.org/jira/browse/VOL-284)