### PR TITLE
VOL-290: Replace mailto: link with activity pop-up in Volunteer roster

### DIFF
--- a/templates/CRM/Volunteer/Page/Roster.tpl
+++ b/templates/CRM/Volunteer/Page/Roster.tpl
@@ -14,11 +14,11 @@
         <td>{$assignment.role_label}</td>
         <td>
           {if $assignment.email}
-            <a href="mailto:{$assignment.email}" title="{ts 1=$assignment.name domain='org.civicrm.volunteer'}Send %1 an email.{/ts}">
+            <a href="{crmURL p='civicrm/activity/email/add' q="action=add&reset=1&cid=`$assignment.contact_id`&atype=Email"}" title="{ts 1=$assignment.name domain='org.civicrm.volunteer'}Send %1 an email.{/ts}" class="crm-popup">
               <input type='button' value="{ts domain='org.civicrm.volunteer'}Email{/ts}" />
             </a>
-            {/if}
-            {if $assignment.email && $assignment.phone}
+          {/if}
+          {if $assignment.email && $assignment.phone}
             |
           {/if}
           {if $assignment.phone}


### PR DESCRIPTION
* [VOL-290: Volunteer roster should send email from CiviCRM System](https://issues.civicrm.org/jira/browse/VOL-290)