### PR TITLE
VOL-312: TFC-94 - Add more detail to volunteer activity when assigned

### DIFF
--- a/CRM/Volunteer/BAO/Assignment.php
+++ b/CRM/Volunteer/BAO/Assignment.php
@@ -247,10 +247,12 @@ class CRM_Volunteer_BAO_Assignment extends CRM_Volunteer_BAO_Activity {
       $defaults['campaign_id'] = '';
     }
 
+    // Taking volunteer_role_id outside of Action ADD scope, we have to update the role on moving the activity.
+    $defaults['volunteer_role_id'] = CRM_Utils_Array::value('role_id', $need);
     if ($op === CRM_Core_Action::ADD) {
-      $defaults['volunteer_role_id'] = CRM_Utils_Array::value('role_id', $need);
       $defaults['time_scheduled_minutes'] = CRM_Utils_Array::value('duration', $need);
-      $defaults['target_contact_id'] = CRM_Volunteer_BAO_Project::getContactsByRelationship($project->id, 'volunteer_beneficiary');
+      $defaults['target_contact_id'] = CRM_Volunteer_BAO_Project::getContactsByRelationship($project->id, 'volunteer_manager'); // Changed to volunteer_manager from volunteer_beneficiary.
+      $defaults['location'] = $project->getLocation(); //Getting location of the project to save in activity.
 
       // If the related entity doesn't provide a good default, use tomorrow.
       if (empty($params['activity_date_time'])) {
@@ -309,6 +311,12 @@ class CRM_Volunteer_BAO_Assignment extends CRM_Volunteer_BAO_Activity {
         $params['custom_' . $field['id']] = $params[$fieldName];
         unset($params[$fieldName]);
       }
+    }
+
+    // Saving the Volunteer role custom field for the activity.
+    $volunteerRoleId = CRM_Core_BAO_CustomField::getCustomFieldID("Volunteer_Role_Id", "CiviVolunteer");
+    if($volunteerRoleId) {
+        $params["custom_{$volunteerRoleId}"] = $defaults["volunteer_role_id"];
     }
 
     $activity = civicrm_api3('Activity', 'create', $params);

--- a/CRM/Volunteer/BAO/Project.php
+++ b/CRM/Volunteer/BAO/Project.php
@@ -169,6 +169,40 @@ class CRM_Volunteer_BAO_Project extends CRM_Volunteer_DAO_Project {
   }
 
   /**
+   * Gets location of a project.
+   *
+   * @return string
+   *   Street Address
+   */
+  public function getLocation() {
+    $location = "";
+    if($this->loc_block_id) {
+        $addressId = civicrm_api3('LocBlock','getvalue', array(
+          'id'         => $this->loc_block_id,
+          'return'     => "address_id"
+        ));
+        if($addressId) {
+          $locationObject = civicrm_api3('Address','getsingle', array(
+            'id'         => $addressId,
+            'return'     => array(
+                "street_address",
+                "city",
+                "state_province_id.name"
+            )
+          ));
+          $location = $locationObject["street_address"];
+          if(!empty($locationObject["city"])) {
+              $location .= ", ".$locationObject["city"];
+          }
+          if(!empty($locationObject["state_province_id.name"])) {
+              $location .= ", ".$locationObject["state_province_id.name"];
+          }
+        }
+    }
+    return $location;
+  }
+
+  /**
    * Strips invalid params, throws exception in case of unusable params.
    *
    * @param array $params


### PR DESCRIPTION
Change fields of activity set when creating from 'Assign Volunteers' page.

1. "With Contact" field is set to be the Volunteer Project, "Manager" instead of "Beneficiary".
2. "Location" field is set to the Volunteer Project, Location, "Street Address" field.
3. Activity custom field "Volunteer Role", based on the assigned role in the Volunteer assignment.

---

 * [VOL-312: Add more detail to volunteer activity when assigned \(TFC-94\)](https://issues.civicrm.org/jira/browse/VOL-312)