### PR TITLE
Fix PHP 7.1 Error: Cannot pass parameter 1 by reference

### DIFF
--- a/CRM/Volunteer/BAO/Project.php
+++ b/CRM/Volunteer/BAO/Project.php
@@ -475,7 +475,8 @@ class CRM_Volunteer_BAO_Project extends CRM_Volunteer_DAO_Project {
     $dao = self::executeQuery($query->toSQL());
     while ($dao->fetch()) {
       $fetchedProject = new CRM_Volunteer_BAO_Project();
-      $fetchedProject->copyValues(clone $dao);
+      $daoClone = clone $dao;
+      $fetchedProject->copyValues($daoClone);
       $result[(int) $dao->id] = $fetchedProject;
     }
     $dao->free();


### PR DESCRIPTION
Before this fix, visiting the "Manage events" page (when at least one event has an associated volunteer project, and the server is running PHP 7.1) would give the following error:

> Error: Cannot pass parameter 1 by reference in CRM_Volunteer_BAO_Project::retrieve() (line 478 of /home/sean/buildkit/build/ext/sites/default/files/civicrm/ext/org.civicrm.volunteer/CRM/Volunteer/BAO/Project.php).

This fix changes the call to `copyValues()` so that it passes a variable, making this code compatible with PHP 7.1 and above.

Here is a comparison of this behavior in different PHP versions: https://3v4l.org/b9Jea