### PR TITLE
VOL-209: Prevents "Error: [$sce:unsafe] Attempting to use an unsafe value in a safe context" if admin-defined help text contains markup.

### DIFF
--- a/ang/volunteer/Project.js
+++ b/ang/volunteer/Project.js
@@ -70,7 +70,7 @@
   );
 
 
-  angular.module('volunteer').controller('VolunteerProject', function($scope, $location, $q, $route, crmApi, crmUiAlert, crmUiHelp, countries, project, profile_status, campaigns, relationship_data, supporting_data, location_blocks, volBackbone) {
+  angular.module('volunteer').controller('VolunteerProject', function($scope, $sce, $location, $q, $route, crmApi, crmUiAlert, crmUiHelp, countries, project, profile_status, campaigns, relationship_data, supporting_data, location_blocks, volBackbone) {
 
     /**
      * We use custom "dirty" logic rather than rely on Angular's native

--- a/volunteer.php
+++ b/volunteer.php
@@ -632,6 +632,7 @@ function volunteer_civicrm_angularModules(&$angularModules) {
       'crmUi',
       'crmUtil',
       'ngRoute',
+      'ngSanitize',
     ),
     'js' =>
       array (


### PR DESCRIPTION
See https://code.angularjs.org/1.5.11/docs/api/ng/service/$sce.