### PR TITLE
VOL-318: Addresses Backbone using CiviCRM's namespace.

### DIFF
--- a/js/backbone/apps/volunteer_app.js
+++ b/js/backbone/apps/volunteer_app.js
@@ -1,5 +1,5 @@
 // http://civicrm.org/licensing
-CRM.volunteerApp = new Backbone.Marionette.Application();
+CRM.volunteerApp = new CRM.BB.Marionette.Application();
 CRM.volunteerApp.addRegions({
   dialogRegion: '#crm-volunteer-dialog',
   searchRegion: '#crm-volunteer-search-dialog'


### PR DESCRIPTION
* [VOL-318: Breakage caused by use of Backbone.noConflict\(\) introduced in CiviCRM 4.7.31](https://issues.civicrm.org/jira/browse/VOL-318)