### PR TITLE
Whether passing through upgrade path or install path, ensure consistent naming of foreign key constraint

### DIFF
--- a/CRM/Volunteer/Upgrader.php
+++ b/CRM/Volunteer/Upgrader.php
@@ -265,7 +265,8 @@ class CRM_Volunteer_Upgrader extends CRM_Volunteer_Upgrader_Base {
     ');
     CRM_Core_DAO::executeQuery('
       ALTER TABLE `civicrm_volunteer_project`
-      ADD FOREIGN KEY (`target_contact_id`)
+      ADD CONSTRAINT `FK_civicrm_volunteer_project_target_contact_id`
+      FOREIGN KEY (`target_contact_id`)
       REFERENCES `civicrm_contact` (`id`)
       ON DELETE SET NULL
     ');


### PR DESCRIPTION
This problem was encountered while upgrading a very out-of-date CiviVolunteer to current.

Without this patch, the upgrade path results in a schema with an autogenerated name for one of its foreign key constraints. In the install path, the same constraint is explicitly provided a name, making it easy to reference in later queries. Later upgrade queries assume the constraint has the name supplied by the installer and will fail if the assumption proves false.