### PR TITLE
Permission.php - Disinherit CRM_*_Permission. Fix warning.

### DIFF
--- a/CRM/Volunteer/Permission.php
+++ b/CRM/Volunteer/Permission.php
@@ -1,6 +1,6 @@
 <?php
 
-class CRM_Volunteer_Permission extends CRM_Core_Permission {
+class CRM_Volunteer_Permission {
 
   const VIEW_ROSTER = 'volunteer_view_roster'; // A number unused by CRM_Core_Action
 
@@ -80,7 +80,7 @@ class CRM_Volunteer_Permission extends CRM_Core_Permission {
       }
     });
 
-    return parent::check($permissions);
+    return CRM_Core_Permission::check($permissions);
   }
 
   /**


### PR DESCRIPTION
On a local demo site with CiviVolunteer (and with `error_reporting(E_ALL)`), anytime I clear the cache
(`/civicrm/clearcache`), it shows this warning:

<img width="1035" alt="screen shot 2018-08-16 at 3 42 44 pm" src="https://user-images.githubusercontent.com/1336047/44238966-ca282000-a16b-11e8-91e2-f86b9847c8f6.png">

This is because `CRM_Volunteer_Permission` extends `CRM_Core_Permission` and overrides `check()`, but the signature for upstream `check()` has changed to allow another argument.

I don't think the inheritance/override relationship here is functionally required -- as near as I can tell:

* Everything in `civicrm-core` which uses `CRM_Core_Permission` calls `CRM_Core_Permission` specifically. They would never substitute with an instance of `CRM_Volunteer_Permission`.
* Everything in `civivolunteer` which needs `CRM_Volunteer_Permission` calls `CRM_Volunteer_Permission`.

What purpose did the inheritance serve?  The idea seems to be this:  "within the CiviVolunteer codebase, we want to use an enhanced version of `check()` which wraps around core's `check()`." But you can do wrappers like that without any inheritance.

I wanted to see if the inheritance serves another purpose -- e.g.  perhaps it calls other inherited methods or properties?  I grepped the CiviVolunteer codebase `CRM_Volunteer_Permission`.  There were 24 matches, but they only referenced three functions: `check()`, `checkProjectPerms()`,
`getVolunteerPermissions()`.  All of these functions are specifically defined in `CRM_Volunteer_Permission`.  Doesn't seem like anything is meaningfully inherited.

I have not done any specific CiviVolunteer UI testing, and I don't know this codebase very deeply... but this patch does resolve the warning.