### PR TITLE
Fixed compatibility with civicrm > 5.3

### DIFF
--- a/api/v3/VolunteerUtil.php
+++ b/api/v3/VolunteerUtil.php
@@ -311,7 +311,7 @@ function civicrm_api3_volunteer_util_getcountries($params) {
  * @return array
  */
 function civicrm_api3_volunteer_util_getcustomfields($params) {
-  $allowedCustomFieldTypes = array('AdvMulti-Select', 'Autocomplete-Select',
+  $allowedCustomFieldTypes = array('Autocomplete-Select',
     'CheckBox', 'Multi-Select', 'Radio', 'Select', 'Text');
 
   $customGroupAPI = civicrm_api3('CustomGroup', 'getsingle', array(

--- a/js/backbone/apps/search/search_views.js
+++ b/js/backbone/apps/search/search_views.js
@@ -29,11 +29,11 @@
          */
         var typeMap = {
           checkRadio: ['CheckBox', 'Radio'],
-          select: ['AdvMulti-Select', 'Autocomplete-Select', 'Multi-Select', 'Select'],
+          select: ['Autocomplete-Select', 'Multi-Select', 'Select'],
           text: ['Text']
         };
         // html_types which allow the user to select multiple values
-        var typeMulti = ['AdvMulti-Select', 'CheckBox', 'Multi-Select'];
+        var typeMulti = ['CheckBox', 'Multi-Select'];
 
         var html_type = this.model.get('html_type');
         var type = _.findKey(typeMap, function(group) {


### PR DESCRIPTION
After upgrading to CiviCRM 5.4.1 we get the following error: 

**'Error in call to CustomField…_get : 'AdvMulti-Select' is not a valid option for field html_type'**

This PR fixes this error. This is caused by the fact that the AdvMulti-Select field is removed since CiviCRM 5.3

