### PR TITLE
fix var-type prefix in select option

### DIFF
--- a/ang/volunteer/VolOppsCtrl.html
+++ b/ang/volunteer/VolOppsCtrl.html
@@ -40,7 +40,7 @@ Required vars: volOppData(), searchParams
               multiple="multiple"
               name="role_id"
               ng-model="searchParams.role_id"
-              ng-options="key as value for (key , value) in  roles"
+              ng-options="key as value for (key , value) in  roles track by key"
               class="big crm-form-text">
               <option />
             </select>


### PR DESCRIPTION
fix variable-type prefixed in option, e.g. "string:4"
https://stackoverflow.com/questions/30120230/how-to-suppress-variable-type-within-value-attribute-using-ng-options#30292209