### PR TITLE
Support full group by mode

### DIFF
--- a/CRM/Volunteer/Form/VolunteerReport.php
+++ b/CRM/Volunteer/Form/VolunteerReport.php
@@ -613,7 +613,7 @@ class CRM_Volunteer_Form_VolunteerReport extends CRM_Report_Form {
   }
 
   function groupBy() {
-    $this->_groupBy = "GROUP BY {$this->_aliases['civicrm_activity']}.id";
+    $this->_groupBy = CRM_Contact_BAO_Query::getGroupByFromSelectColumns($this->_selectClauses, "{$this->_aliases['civicrm_activity']}.id");
   }
 
   function buildACLClause($tableAlias = 'contact_a') {


### PR DESCRIPTION
https://civicrm.stackexchange.com/questions/26810/volunteer-report-error-expression-2-of-select-list-is-not-in-group-by-clause