### PR TITLE
Add icon to top level menu entry

### DIFF
--- a/volunteer.php
+++ b/volunteer.php
@@ -51,6 +51,7 @@ function volunteer_civicrm_navigationMenu(&$menu) {
     'permission' => NULL,
     'operator' => NULL,
     'separator' => 0,
+    'icon' => 'crm-i fa-users',
   ));
 
   _volunteer_civix_insert_navigation_menu($menu, 'volunteer_volunteers', array(


### PR DESCRIPTION
This makes the menu entry look nice.

Note: I couldn't think of a better icon than this. Even though it's already designated as signifying "groups" in civicrm I think it's ok to mean volunteers too.