### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/CRM/Volunteer/Angular.php
+++ b/CRM/Volunteer/Angular.php
@@ -2,7 +2,7 @@
 
 class CRM_Volunteer_Angular {
 
-  private static $loaded = FALSE;
+  private static $loaded = false;
 
   /**
    * @return boolean
@@ -34,7 +34,7 @@ class CRM_Volunteer_Angular {
       ),
     ));
 
-    self::$loaded = TRUE;
+    self::$loaded = true;
   }
 
 }

--- a/CRM/Volunteer/BAO/Assignment.php
+++ b/CRM/Volunteer/BAO/Assignment.php
@@ -91,7 +91,7 @@ class CRM_Volunteer_BAO_Assignment extends CRM_Volunteer_BAO_Activity {
     }
     $customSelect = implode(', ', $selectClause);
 
-    $activityContactTypes = CRM_Core_OptionGroup::values('activity_contacts', FALSE, FALSE, FALSE, NULL, 'name');
+    $activityContactTypes = CRM_Core_OptionGroup::values('activity_contacts', false, false, false, null, 'name');
     $assigneeID = CRM_Utils_Array::key('Activity Assignees', $activityContactTypes);
     $targetID = CRM_Utils_Array::key('Activity Targets', $activityContactTypes);
 
@@ -109,7 +109,7 @@ class CRM_Volunteer_BAO_Assignment extends CRM_Volunteer_BAO_Activity {
 
     $i = count($placeholders) + 1;
     $where = array();
-    $whereClause = NULL;
+    $whereClause = null;
     foreach ($filtered_params as $key => $value) {
 
       if (CRM_Utils_Array::value($key, $activity_fields)) {
@@ -320,7 +320,7 @@ class CRM_Volunteer_BAO_Assignment extends CRM_Volunteer_BAO_Activity {
     }
 
     $activity = civicrm_api3('Activity', 'create', $params);
-    return empty($activity['id']) ? FALSE : $activity['id'];
+    return empty($activity['id']) ? false : $activity['id'];
   }
 
 }

--- a/CRM/Volunteer/BAO/Commendation.php
+++ b/CRM/Volunteer/BAO/Commendation.php
@@ -78,9 +78,9 @@ class CRM_Volunteer_BAO_Commendation extends CRM_Volunteer_BAO_Activity {
         CRM_Utils_Array::value('vid', $params) // volunteer project id
       )
     ) {
-      return TRUE;
+      return true;
     }
-    return FALSE;
+    return false;
   }
 
   /**
@@ -118,7 +118,7 @@ class CRM_Volunteer_BAO_Commendation extends CRM_Volunteer_BAO_Activity {
     }
     $customSelect = implode(', ', $selectClause);
 
-    $activityContactTypes = CRM_Core_OptionGroup::values('activity_contacts', FALSE, FALSE, FALSE, NULL, 'name');
+    $activityContactTypes = CRM_Core_OptionGroup::values('activity_contacts', false, false, false, null, 'name');
     $targetID = CRM_Utils_Array::key('Activity Targets', $activityContactTypes);
 
     $placeholders = array(
@@ -128,7 +128,7 @@ class CRM_Volunteer_BAO_Commendation extends CRM_Volunteer_BAO_Activity {
 
     $i = count($placeholders) + 1;
     $where = array();
-    $whereClause = NULL;
+    $whereClause = null;
     foreach ($filtered_params as $key => $value) {
 
       if (CRM_Utils_Array::value($key, $activity_fields)) {

--- a/CRM/Volunteer/BAO/Need.php
+++ b/CRM/Volunteer/BAO/Need.php
@@ -68,7 +68,7 @@ class CRM_Volunteer_BAO_Need extends CRM_Volunteer_DAO_Need {
     $need->copyValues($params);
     $projectId = $need->getProjectId();
 
-    if ($projectId === FALSE) {
+    if ($projectId === false) {
       CRM_Core_Error::fatal('Missing required Need ID or Project ID');
     }
 
@@ -79,13 +79,13 @@ class CRM_Volunteer_BAO_Need extends CRM_Volunteer_DAO_Need {
 
       // FIXME: If we don't return here, the script keeps executing. This is not
       // what I expect from CRM_Utils_System::permissionDenied().
-      return FALSE;
+      return false;
     }
 
     // VOL-269: Do not allow creation of more than one flexible need per project.
     if ($need->is_flexible) {
       $existingNeedId = CRM_Volunteer_BAO_Project::getFlexibleNeedID($projectId);
-      $thisNeedId = property_exists($need, 'id') ? (int) $need->id : NULL;
+      $thisNeedId = property_exists($need, 'id') ? (int) $need->id : null;
       if ($existingNeedId === $thisNeedId) {
         CRM_Core_Error::fatal('Cannot create more than one flexible need for a given project');
       }
@@ -114,17 +114,17 @@ class CRM_Volunteer_BAO_Need extends CRM_Volunteer_DAO_Need {
   public function getProjectId() {
     // If the project ID was passed into the create method, or if the object is
     // already fully loaded, we already have the project ID and can return it...
-    if (isset($this->project_id) && CRM_Utils_Type::validate($this->project_id, 'Positive', FALSE)) {
+    if (isset($this->project_id) && CRM_Utils_Type::validate($this->project_id, 'Positive', false)) {
       return (int) $this->project_id;
     }
 
     // ... otherwise we have to look it up from the database
-    if (isset($this->id) && CRM_Utils_Type::validate($this->id, 'Positive', FALSE)) {
+    if (isset($this->id) && CRM_Utils_Type::validate($this->id, 'Positive', false)) {
       $dbNeed = $this->findById($this->id);
       return $dbNeed->project_id;
     }
 
-    return FALSE;
+    return false;
   }
 
   /**
@@ -166,9 +166,9 @@ class CRM_Volunteer_BAO_Need extends CRM_Volunteer_DAO_Need {
    *   Returns a string on success, boolean FALSE if $start is not
    *   a parseable time.
    */
-  static function getTimes($start, $duration = NULL, $end = NULL) {
+  static function getTimes($start, $duration = null, $end = null) {
     if (!strtotime($start)) {
-      return FALSE;
+      return false;
     }
 
     $config = CRM_Core_Config::singleton();
@@ -177,7 +177,7 @@ class CRM_Volunteer_BAO_Need extends CRM_Volunteer_DAO_Need {
 
     if (strtotime($end)) {
       $result .= ' - ' . CRM_Utils_Date::customFormat($end, $timeFormat);
-    } elseif (CRM_Utils_Type::validate($duration, 'Positive', FALSE)) {
+    } elseif (CRM_Utils_Type::validate($duration, 'Positive', false)) {
       $date = new DateTime($start);
       $startDay = $date->format('Y-m-d');
       $date->add(new DateInterval("PT{$duration}M"));
@@ -226,9 +226,9 @@ class CRM_Volunteer_BAO_Need extends CRM_Volunteer_DAO_Need {
       }
     }
     else {
-      return FALSE;
+      return false;
     }
-    return TRUE;
+    return true;
   }
 
   /**

--- a/CRM/Volunteer/BAO/NeedSearch.php
+++ b/CRM/Volunteer/BAO/NeedSearch.php
@@ -113,26 +113,26 @@ class CRM_Volunteer_BAO_NeedSearch {
     $needEndTime = strtotime(CRM_Utils_Array::value('end_time', $need));
 
     // There are no date-related search criteria, so we're done here.
-    if ($this->searchParams['need']['date_start'] === FALSE && $this->searchParams['need']['date_end'] === FALSE) {
-      return TRUE;
+    if ($this->searchParams['need']['date_start'] === false && $this->searchParams['need']['date_end'] === false) {
+      return true;
     }
 
     // The search window has no end time. We need to verify only that the need
     // has dates after the start time.
-    if ($this->searchParams['need']['date_end'] === FALSE) {
+    if ($this->searchParams['need']['date_end'] === false) {
       return $needStartTime >= $this->searchParams['need']['date_start'] || $needEndTime >= $this->searchParams['need']['date_start'];
     }
 
     // The search window has no start time. We need to verify only that the need
     // starts before the end of the window.
-    if ($this->searchParams['need']['date_start'] === FALSE) {
+    if ($this->searchParams['need']['date_start'] === false) {
       return $needStartTime <= $this->searchParams['need']['date_end'];
     }
 
     // The need does not have fuzzy dates, and both ends of the search
     // window have been specified. We need to verify only that the need
     // starts in the search window.
-    if ($needEndTime === FALSE) {
+    if ($needEndTime === false) {
       return $needStartTime >= $this->searchParams['need']['date_start'] && $needStartTime <= $this->searchParams['need']['date_end'];
     }
 
@@ -178,7 +178,7 @@ class CRM_Volunteer_BAO_NeedSearch {
     $this->setSearchDateParams($userSearchParams);
 
     $projectId = CRM_Utils_Array::value('project', $userSearchParams);
-    if (CRM_Utils_Type::validate($projectId, 'Positive', FALSE)) {
+    if (CRM_Utils_Type::validate($projectId, 'Positive', false)) {
       $this->searchParams['project']['id'] = $projectId;
     }
 
@@ -247,23 +247,23 @@ class CRM_Volunteer_BAO_NeedSearch {
       // Because of CRM-17327, the chained "get" may improperly report its result,
       // so we check the value we're chaining off of to decide whether or not
       // to trust the result.
-      $project['campaign_title'] = empty($api['campaign_id']) ? NULL : $api['api.Campaign.getvalue'];
+      $project['campaign_title'] = empty($api['campaign_id']) ? null : $api['api.Campaign.getvalue'];
 
       // CRM-17327
       if (empty($api['loc_block_id']) || empty($api['api.LocBlock.getsingle']['address_id'])) {
         $project['location'] = array(
-          'city' => NULL,
-          'country' => NULL,
-          'postal_code' => NULL,
-          'state_provice' => NULL,
-          'street_address' => NULL,
+          'city' => null,
+          'country' => null,
+          'postal_code' => null,
+          'state_provice' => null,
+          'street_address' => null,
         );
       } else {
         $countryId = $api['api.LocBlock.getsingle']['api.Address.getsingle']['country_id'];
-        $country = $countryId ? CRM_Core_PseudoConstant::country($countryId) : NULL;
+        $country = $countryId ? CRM_Core_PseudoConstant::country($countryId) : null;
 
         $stateProvinceId = $api['api.LocBlock.getsingle']['api.Address.getsingle']['state_province_id'];
-        $stateProvince = $stateProvinceId ? CRM_Core_PseudoConstant::stateProvince($stateProvinceId) : NULL;
+        $stateProvince = $stateProvinceId ? CRM_Core_PseudoConstant::stateProvince($stateProvinceId) : null;
 
         $project['location'] = array(
           'city' => $api['api.LocBlock.getsingle']['api.Address.getsingle']['city'],

--- a/CRM/Volunteer/BAO/Project.php
+++ b/CRM/Volunteer/BAO/Project.php
@@ -136,7 +136,7 @@ class CRM_Volunteer_BAO_Project extends CRM_Volunteer_DAO_Project {
    * @return boolean
    */
   function __isset($name) {
-    $result = FALSE;
+    $result = false;
     $f = "_get_$name";
     if (method_exists($this, $f)) {
       $v = $this->$f();
@@ -263,7 +263,7 @@ class CRM_Volunteer_BAO_Project extends CRM_Volunteer_DAO_Project {
 
       // FIXME: If we don't return here, the script keeps executing. This is not
       // what I expect from CRM_Utils_System::permissionDenied().
-      return FALSE;
+      return false;
     }
 
     $params = self::validateCreateParams($params);
@@ -282,8 +282,8 @@ class CRM_Volunteer_BAO_Project extends CRM_Volunteer_DAO_Project {
     if ($op === CRM_Core_Action::ADD) {
       CRM_Volunteer_BAO_Need::create(array(
         // Save an unnecessary lookup for a perms check that will always succeed.
-        'check_permissions' => FALSE,
-        'is_flexible' => TRUE,
+        'check_permissions' => false,
+        'is_flexible' => true,
         'project_id' => $project->id,
         'visibility_id' => 'admin',
       ));
@@ -390,7 +390,7 @@ class CRM_Volunteer_BAO_Project extends CRM_Volunteer_DAO_Project {
       $p = current($projects);
       return $p->is_active;
     }
-    return NULL;
+    return null;
   }
 
   /**
@@ -400,10 +400,10 @@ class CRM_Volunteer_BAO_Project extends CRM_Volunteer_DAO_Project {
    * @param int $projectId
    * @return boolean
    */
-  private static function allowedToRetrieve($projectId = NULL) {
+  private static function allowedToRetrieve($projectId = null) {
     $userCanView = CRM_Volunteer_Permission::checkProjectPerms(CRM_Core_Action::VIEW);
 
-    $userCanViewRoster = FALSE;
+    $userCanViewRoster = false;
     if (!$userCanView && !empty($projectId)) {
       $userCanViewRoster = CRM_Volunteer_Permission::checkProjectPerms(CRM_Volunteer_Permission::VIEW_ROSTER, $projectId);
     }
@@ -496,15 +496,15 @@ class CRM_Volunteer_BAO_Project extends CRM_Volunteer_DAO_Project {
    *   String SQL fragment otherwise
    */
   private static function buildContactJoin(array $projectContacts) {
-    $result = FALSE;
+    $result = false;
     $onClauses = array();
 
     $relTypes = CRM_Core_OptionGroup::values(
       CRM_Volunteer_BAO_ProjectContact::RELATIONSHIP_OPTION_GROUP,
-      TRUE, FALSE, FALSE, NULL, 'name');
+      true, false, false, null, 'name');
 
     foreach ($projectContacts as $relType => $contactIds) {
-      if (!CRM_Utils_Type::validate($relType, 'Integer', FALSE)) {
+      if (!CRM_Utils_Type::validate($relType, 'Integer', false)) {
         $relType = $relTypes[$relType];
       }
       $contactIds = implode(',', (array) $contactIds);
@@ -540,7 +540,7 @@ class CRM_Volunteer_BAO_Project extends CRM_Volunteer_DAO_Project {
    * @throws Exception
    */
   private static function buildProximityWhere(array $params) {
-    $country = $lat = $lon = $radius = $unit = NULL;
+    $country = $lat = $lon = $radius = $unit = null;
     extract($params, EXTR_IF_EXISTS);
 
     // ensure that radius is a float
@@ -564,7 +564,7 @@ class CRM_Volunteer_BAO_Project extends CRM_Volunteer_DAO_Project {
 
       // TODO: I think CRM_Utils_Geocode_*::format should be responsible for this
       // If/when CRM-17245 is closed, this if-block can be removed.
-      if (CRM_Utils_Type::validate($country, 'Positive', FALSE)) {
+      if (CRM_Utils_Type::validate($country, 'Positive', false)) {
         $params['country'] = civicrm_api3('Country', 'getvalue', array(
           'id' => $country,
           'return' => 'name',
@@ -618,10 +618,10 @@ class CRM_Volunteer_BAO_Project extends CRM_Volunteer_DAO_Project {
    * @access public
    */
   public static function isOff($value) {
-    if (in_array($value, array(FALSE, 0, '0'), TRUE)) {
-      return TRUE;
+    if (in_array($value, array(false, 0, '0'), true)) {
+      return true;
     } else {
-      return FALSE;
+      return false;
     }
   }
 
@@ -632,7 +632,7 @@ class CRM_Volunteer_BAO_Project extends CRM_Volunteer_DAO_Project {
    * @deprecated since version 4.7.21-2.3.0
    *   Internal core methods should not be extended by third-party code.
    */
-  public function copyValues(&$params, $serializeArrays = FALSE) {
+  public function copyValues(&$params, $serializeArrays = false) {
     if (is_a($params, 'CRM_Core_DAO')) {
       $params = get_object_vars($params);
     }
@@ -657,7 +657,7 @@ class CRM_Volunteer_BAO_Project extends CRM_Volunteer_DAO_Project {
   public function getEntityAttributes() {
     if (!$this->entityAttributes) {
       $arrayKeys = array('start_time', 'title');
-      $this->entityAttributes = array_fill_keys($arrayKeys, NULL);
+      $this->entityAttributes = array_fill_keys($arrayKeys, null);
 
       if ($this->entity_table && $this->entity_id) {
         try {
@@ -675,7 +675,7 @@ class CRM_Volunteer_BAO_Project extends CRM_Volunteer_DAO_Project {
           $format = 'Could not fetch entity attributes for volunteer project with ID %d. '
             . 'No %s with ID %d exists; perhaps it has been deleted.';
           $msg = sprintf($format, $this->id, $this->entity_table, $this->entity_id);
-          CRM_Core_Error::debug_log_message($msg, FALSE, 'org.civicrm.volunteer');
+          CRM_Core_Error::debug_log_message($msg, false, 'org.civicrm.volunteer');
         }
       }
     }
@@ -689,7 +689,7 @@ class CRM_Volunteer_BAO_Project extends CRM_Volunteer_DAO_Project {
    * @return mixed Integer on success, else NULL
    */
   public static function getFlexibleNeedID ($project_id) {
-    $result = NULL;
+    $result = null;
 
     if (is_int($project_id) || ctype_digit($project_id)) {
       $flexibleNeed = civicrm_api('volunteer_need', 'getvalue', array(
@@ -789,7 +789,7 @@ class CRM_Volunteer_BAO_Project extends CRM_Volunteer_DAO_Project {
    */
   public static function getDefaultProjectContacts() {
     $defaults = array();
-    $optionMap = CRM_Core_OptionGroup::values("volunteer_project_relationship", TRUE, FALSE, FALSE, NULL, 'name');
+    $optionMap = CRM_Core_OptionGroup::values("volunteer_project_relationship", true, false, false, null, 'name');
     $projectContactsSetting = civicrm_api3('Setting', 'getvalue', array(
       'name' => 'volunteer_project_default_contacts',
     ));

--- a/CRM/Volunteer/Form/Commendation.php
+++ b/CRM/Volunteer/Form/Commendation.php
@@ -33,9 +33,9 @@ class CRM_Volunteer_Form_Commendation extends CRM_Core_Form {
    * if you are messing with URL params you are kind of asking for trouble...
    */
   function preProcess() {
-    $this->_aid = CRM_Utils_Request::retrieve('aid', 'Positive', $this, FALSE);
-    $this->_cid = CRM_Utils_Request::retrieve('cid', 'Positive', $this, FALSE);
-    $this->_vid = CRM_Utils_Request::retrieve('vid', 'Positive', $this, FALSE);
+    $this->_aid = CRM_Utils_Request::retrieve('aid', 'Positive', $this, false);
+    $this->_cid = CRM_Utils_Request::retrieve('cid', 'Positive', $this, false);
+    $this->_vid = CRM_Utils_Request::retrieve('vid', 'Positive', $this, false);
 
     if (!CRM_Volunteer_Permission::checkProjectPerms(CRM_Core_Action::UPDATE, $this->_vid)) {
       CRM_Utils_System::permissionDenied();
@@ -119,7 +119,7 @@ class CRM_Volunteer_Form_Commendation extends CRM_Core_Form {
     $buttons = array(
       array(
         'type' => 'submit',
-        'isDefault' => TRUE,
+        'isDefault' => true,
       ),
     );
     if (isset($this->_aid)) {

--- a/CRM/Volunteer/Form/IncludeProfile.php
+++ b/CRM/Volunteer/Form/IncludeProfile.php
@@ -9,7 +9,7 @@ require_once 'CRM/Core/Form.php';
  */
 class CRM_Volunteer_Form_IncludeProfile extends CRM_Core_Form {
   function buildQuickForm() {
-    $profileCount = CRM_Utils_Array::value('profileCount', $_GET, FALSE);
+    $profileCount = CRM_Utils_Array::value('profileCount', $_GET, false);
     self::buildProfileWidget($this, $profileCount);
     $this->assign('profileCount', $profileCount);
 

--- a/CRM/Volunteer/Form/Log.php
+++ b/CRM/Volunteer/Form/Log.php
@@ -56,7 +56,7 @@ class CRM_Volunteer_Form_Log extends CRM_Core_Form {
    * @access public
    */
   function preProcess() {
-    $this->_vid = CRM_Utils_Request::retrieve('vid', 'Positive', $this, TRUE);
+    $this->_vid = CRM_Utils_Request::retrieve('vid', 'Positive', $this, true);
 
     if (!CRM_Volunteer_Permission::checkProjectPerms(CRM_Core_Action::UPDATE, $this->_vid)) {
       CRM_Utils_System::permissionDenied();
@@ -113,7 +113,7 @@ class CRM_Volunteer_Form_Log extends CRM_Core_Form {
       array(
         'type' => 'upload',
         'name' => ts('Save', array('domain' => 'org.civicrm.volunteer')),
-        'isDefault' => TRUE
+        'isDefault' => true
       ),
       array(
         'type' => 'cancel',
@@ -133,11 +133,11 @@ class CRM_Volunteer_Form_Log extends CRM_Core_Form {
     for ($rowNumber = 1; $rowNumber <= $this->_batchInfo['item_count']; $rowNumber++) {
       $extra = array();
       $entityRefParams = array(
-        'create' => TRUE,
+        'create' => true,
         'class' => 'big required',
         'placeholder' => ts('- select -', array('domain' => 'org.civicrm.volunteer')),
       );
-      $isRequired = FALSE;
+      $isRequired = false;
       $contactField = $this->addEntityRef("field[$rowNumber][contact_id]", '', $entityRefParams, $isRequired);
 
       $datePickerAttr = array('formatType' => 'activityDateTime');
@@ -145,7 +145,7 @@ class CRM_Volunteer_Form_Log extends CRM_Core_Form {
         // readonly for some fields
         $contactField->freeze();
         $extra = array(
-          'READONLY' => TRUE,
+          'READONLY' => true,
           'style' => "background-color:#EBECE4",
           'disabled' => 'disabled'
         );
@@ -216,7 +216,7 @@ class CRM_Volunteer_Form_Log extends CRM_Core_Form {
       return $errors;
     }
 
-    return TRUE;
+    return true;
   }
 
   /**
@@ -290,7 +290,7 @@ class CRM_Volunteer_Form_Log extends CRM_Core_Form {
           'time_scheduled_minutes' => CRM_Utils_Array::value('scheduled_duration', $value),
         );
         if (!empty($value['start_date'])) {
-          $volunteer['activity_date_time'] = CRM_Utils_Date::processDate($value['start_date'], $value['start_date_time'], TRUE);
+          $volunteer['activity_date_time'] = CRM_Utils_Date::processDate($value['start_date'], $value['start_date_time'], true);
         }
 
         CRM_Volunteer_BAO_Assignment::createVolunteerActivity($volunteer);

--- a/CRM/Volunteer/Form/Settings.php
+++ b/CRM/Volunteer/Form/Settings.php
@@ -165,7 +165,7 @@ class CRM_Volunteer_Form_Settings extends CRM_Core_Form {
       array(
         'type' => 'submit',
         'name' => ts('Save Volunteer Settings', array('domain' => 'org.civicrm.volunteer')),
-        'isDefault' => TRUE,
+        'isDefault' => true,
       ),
     ));
     // export form elements
@@ -183,8 +183,8 @@ class CRM_Volunteer_Form_Settings extends CRM_Core_Form {
         $data['label'],
         $this->getProjectRelationshipSettingModes(),
         array("data-fieldgroup" => "Default Project Settings",),
-        NULL,
-        TRUE
+        null,
+        true
       );
 
       // EntityRef is not used because a select list not easily obtainable through a single API call is needed
@@ -197,7 +197,7 @@ class CRM_Volunteer_Form_Settings extends CRM_Core_Form {
         array(
           'class' => 'crm-select2',
           'data-fieldgroup' => 'Default Project Settings',
-          'placeholder' => TRUE,
+          'placeholder' => true,
         )
       );
 
@@ -205,7 +205,7 @@ class CRM_Volunteer_Form_Settings extends CRM_Core_Form {
         "volunteer_project_default_contacts_contact_$name",
         ts('Default to Selected Contact(s)', array('domain' => 'org.civicrm.volunteer')),
         array(
-          'multiple' => TRUE,
+          'multiple' => true,
           'data-fieldgroup' => "Default Project Settings",
         )
       );
@@ -216,7 +216,7 @@ class CRM_Volunteer_Form_Settings extends CRM_Core_Form {
    * Assigns help text to the form object for use in the template layer.
    */
   private function buildHelpText() {
-    $newProjectUrl = CRM_Utils_System::url('civicrm/vol/', NULL, FALSE, 'volunteer/manage/0');
+    $newProjectUrl = CRM_Utils_System::url('civicrm/vol/', null, false, 'volunteer/manage/0');
     $helpText = '<p>' . ts('The values set in this section will be used as defaults for volunteer projects in both the form and data layers.', array('domain' => 'org.civicrm.volunteer')) . '</p>';
     $helpText .= '<p>' . ts('Streamline creation of new volunteer projects by selecting the options you choose most. The <a href="%1">New Project screen</a> will open with these settings already selected. These values will also be used for projects created through API unless other values are specified.', array(1 => $newProjectUrl, 'domain' => 'org.civicrm.volunteer')) . '</p>';
     $helpText .= '<p>' . ts('Note: Projects created by users who do not have the "edit volunteer project relationships" or "edit volunteer registration profiles" permissions will always use the defaults for those fields.', array('domain' => 'org.civicrm.volunteer')) . '</p>';
@@ -395,7 +395,7 @@ class CRM_Volunteer_Form_Settings extends CRM_Core_Form {
    *   String or NULL
    */
   private function getGroupName(HTML_QuickForm_element $element) {
-    $groupName = NULL;
+    $groupName = null;
 
     // radios and checkboxes are nested inside HTML_QuickForm_group objects;
     // check *their* elements for the data-fieldgroup attribute
@@ -502,7 +502,7 @@ class CRM_Volunteer_Form_Settings extends CRM_Core_Form {
 
       if ($mode === 'acting_contact') {
         // For interface consistency we supply a 'value' key though it isn't strictly needed.
-        $store[$name]['value'] = TRUE;
+        $store[$name]['value'] = true;
       }
       else {
         $fieldName = "volunteer_project_default_contacts_{$mode}_{$name}";

--- a/CRM/Volunteer/Form/VolunteerReport.php
+++ b/CRM/Volunteer/Form/VolunteerReport.php
@@ -49,8 +49,8 @@ class CRM_Volunteer_Form_VolunteerReport extends CRM_Report_Form {
           'project' => array(
             'name' => 'title',
             'title' => ts('Project', array('domain' => 'org.civicrm.volunteer')),
-            'no_repeat' => TRUE,
-            'default' => TRUE,
+            'no_repeat' => true,
+            'default' => true,
           ),
         ),
         'alias' => 'project',
@@ -69,14 +69,14 @@ class CRM_Volunteer_Form_VolunteerReport extends CRM_Report_Form {
             'name' => 'sort_name',
             'title' => ts('Volunteer Name', array('domain' => 'org.civicrm.volunteer')),
             'alias' => 'civicrm_contact_assignee_civireport',
-            'default' => TRUE,
-            'required' => TRUE,
+            'default' => true,
+            'required' => true,
           ),
           'contact_source' => array(
             'name' => 'sort_name',
             'title' => ts('Source Contact Name', array('domain' => 'org.civicrm.volunteer')),
             'alias' => 'civicrm_contact_source',
-            'no_repeat' => TRUE,
+            'no_repeat' => true,
           ),
           'contact_target' => array(
             'name' => 'sort_name',
@@ -137,7 +137,7 @@ class CRM_Volunteer_Form_VolunteerReport extends CRM_Report_Form {
         'fields' => array(
           'organization_id' => array(
             'name' => 'id',
-            'no_display' => TRUE,
+            'no_display' => true,
           ),
           'organization_name' => array(
             'title' => ts('Employer', array('domain' => 'org.civicrm.volunteer')),
@@ -173,29 +173,29 @@ class CRM_Volunteer_Form_VolunteerReport extends CRM_Report_Form {
         'dao' => 'CRM_Activity_DAO_Activity',
         'fields' => array(
           'id' => array(
-            'no_display' => TRUE,
-            'required' => TRUE,
+            'no_display' => true,
+            'required' => true,
           ),
           'source_record_id' => array(
-            'no_display' => TRUE,
-            'required' => TRUE,
+            'no_display' => true,
+            'required' => true,
           ),
           'activity_type_id' => array(
-            'no_display' => TRUE,
-            'required' => TRUE,
+            'no_display' => true,
+            'required' => true,
           ),
           'activity_subject' => array(
             'title' => ts('Subject', array('domain' => 'org.civicrm.volunteer')),
-            'default' => TRUE,
+            'default' => true,
           ),
           'activity_date_time' => array(
             'title' => ts('Scheduled Date/Time', array('domain' => 'org.civicrm.volunteer')),
-            'default' => TRUE,
+            'default' => true,
             'type' => CRM_Utils_Type::T_STRING,
           ),
           'status_id' => array(
             'title' => ts('Activity Status', array('domain' => 'org.civicrm.volunteer')),
-            'default' => TRUE,
+            'default' => true,
             'type' => CRM_Utils_Type::T_STRING,
           ),
         ),
@@ -229,8 +229,8 @@ class CRM_Volunteer_Form_VolunteerReport extends CRM_Report_Form {
         'dao' => 'CRM_Activity_DAO_ActivityContact',
         'fields' => array(
           'contact_id' => array(
-            'no_display' => TRUE,
-            'required' => TRUE,
+            'no_display' => true,
+            'required' => true,
           ),
         ),
         'alias' => 'activity_assignment',
@@ -239,8 +239,8 @@ class CRM_Volunteer_Form_VolunteerReport extends CRM_Report_Form {
         'dao' => 'CRM_Activity_DAO_ActivityContact',
         'fields' => array(
           'contact_id' => array(
-            'no_display' => TRUE,
-            'required' => TRUE,
+            'no_display' => true,
+            'required' => true,
           ),
         ),
         'alias' => 'activity_target',
@@ -249,8 +249,8 @@ class CRM_Volunteer_Form_VolunteerReport extends CRM_Report_Form {
         'dao' => 'CRM_Activity_DAO_ActivityContact',
         'fields' => array(
           'contact_id' => array(
-            'no_display' => TRUE,
-            'required' => TRUE,
+            'no_display' => true,
+            'required' => true,
           ),
         ),
         'alias' => 'activity_source',
@@ -261,8 +261,8 @@ class CRM_Volunteer_Form_VolunteerReport extends CRM_Report_Form {
             'name' => $this->customFields['volunteer_role_id']['column_name'],
             'title' => ts('Volunteer Role', array('domain' => 'org.civicrm.volunteer')),
             'alias' => 'cg',
-            'no_repeat' => TRUE,
-            'default' => TRUE,
+            'no_repeat' => true,
+            'default' => true,
           ),
         ),
         'order_bys' => array(
@@ -276,8 +276,8 @@ class CRM_Volunteer_Form_VolunteerReport extends CRM_Report_Form {
             'name' => $this->customFields['time_scheduled_minutes']['column_name'],
             'title' => ts('Time Scheduled in Minutes', array('domain' => 'org.civicrm.volunteer')),
             'alias' => 'cg',
-            'no_repeat' => TRUE,
-            'default' => TRUE,
+            'no_repeat' => true,
+            'default' => true,
           ),
         ),
       ),
@@ -287,8 +287,8 @@ class CRM_Volunteer_Form_VolunteerReport extends CRM_Report_Form {
             'name' => $this->customFields['time_completed_minutes']['column_name'],
             'title' => ts('Time Completed in Minutes', array('domain' => 'org.civicrm.volunteer')),
             'alias' => 'cg',
-            'no_repeat' => TRUE,
-            'default' => TRUE,
+            'no_repeat' => true,
+            'default' => true,
           ),
         ),
       ),
@@ -297,8 +297,8 @@ class CRM_Volunteer_Form_VolunteerReport extends CRM_Report_Form {
         'fields' => array(
           'case_id' => array(
             'name' => 'case_id',
-            'no_display' => TRUE,
-            'required' => TRUE,
+            'no_display' => true,
+            'required' => true,
           ),
         ),
         'alias' => 'case_activity',
@@ -307,8 +307,8 @@ class CRM_Volunteer_Form_VolunteerReport extends CRM_Report_Form {
 
     $this->addPhoneFields();
 
-    $this->_groupFilter = TRUE;
-    $this->_tagFilter = TRUE;
+    $this->_groupFilter = true;
+    $this->_tagFilter = true;
     parent::__construct();
   }
 
@@ -370,7 +370,7 @@ class CRM_Volunteer_Form_VolunteerReport extends CRM_Report_Form {
   function select() {
     // Require the contact ID if the employer is selected so we can hyperlink to the record.
     if ($this->isTableSelected('civicrm_contact_organization')) {
-      $this->_columns['civicrm_contact_organization']['fields']['organization_id']['required'] = TRUE;
+      $this->_columns['civicrm_contact_organization']['fields']['organization_id']['required'] = true;
     }
 
     $select = array();
@@ -413,7 +413,7 @@ class CRM_Volunteer_Form_VolunteerReport extends CRM_Report_Form {
   }
 
   function from() {
-    $activityContacts = CRM_Core_OptionGroup::values('activity_contacts', FALSE, FALSE, FALSE, NULL, 'name');
+    $activityContacts = CRM_Core_OptionGroup::values('activity_contacts', false, false, false, null, 'name');
     $roleID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', 'volunteer_role', 'id','name');
     $assigneeID = CRM_Utils_Array::key('Activity Assignees', $activityContacts);
     $targetID = CRM_Utils_Array::key('Activity Targets', $activityContacts);
@@ -528,7 +528,7 @@ class CRM_Volunteer_Form_VolunteerReport extends CRM_Report_Form {
       if (array_key_exists('filters', $table)) {
 
         foreach ($table['filters'] as $fieldName => $field) {
-          $clause = NULL;
+          $clause = null;
           if (CRM_Utils_Array::value('type', $field) & CRM_Utils_Type::T_DATE) {
             $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
             $from     = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
@@ -556,11 +556,11 @@ class CRM_Volunteer_Form_VolunteerReport extends CRM_Report_Form {
                 $clause = "( civicrm_contact_source.id = " . $contactID . " OR civicrm_contact_assignee.id = " . $contactID . " OR contact_civireport.id = " . $contactID . " )";
               }
               else {
-                $clause = NULL;
+                $clause = null;
               }
             }
             else {
-              $clause = NULL;
+              $clause = null;
             }
           }
           if (!empty($clause)) {
@@ -621,7 +621,7 @@ class CRM_Volunteer_Form_VolunteerReport extends CRM_Report_Form {
     // contact/assignee or target also it may be null )
 
     if (CRM_Core_Permission::check('view all contacts')) {
-      $this->_aclFrom = $this->_aclWhere = NULL;
+      $this->_aclFrom = $this->_aclWhere = null;
       return;
     }
 
@@ -639,7 +639,7 @@ class CRM_Volunteer_Form_VolunteerReport extends CRM_Report_Form {
     }
 
     $this->_aclFrom = implode(" ", $clauses);
-    $this->_aclWhere = NULL;
+    $this->_aclWhere = null;
   }
 
   function preProcessCommon() {
@@ -693,16 +693,16 @@ class CRM_Volunteer_Form_VolunteerReport extends CRM_Report_Form {
   function alterDisplay(&$rows) {
     // custom code to alter rows
 
-    $entryFound     = FALSE;
-    $activityType   = CRM_Core_PseudoConstant::activityType(TRUE, TRUE, FALSE, 'label', TRUE);
+    $entryFound     = false;
+    $activityType   = CRM_Core_PseudoConstant::activityType(true, true, false, 'label', true);
     $activityStatus = CRM_Core_PseudoConstant::activityStatus();
     $volunteerRoles = CRM_Volunteer_BAO_Need::buildOptions('role_id', 'create');
-    $viewLinks      = FALSE;
+    $viewLinks      = false;
     $seperator      = CRM_CORE_DAO::VALUE_SEPARATOR;
-    $context        = CRM_Utils_Request::retrieve('context', 'String', $this, FALSE, 'report');
+    $context        = CRM_Utils_Request::retrieve('context', 'String', $this, false, 'report');
 
     if (CRM_Core_Permission::check('access CiviCRM')) {
-      $viewLinks  = TRUE;
+      $viewLinks  = true;
       $onHover    = ts('View Contact Summary for this Contact', array('domain' => 'org.civicrm.volunteer'));
       $onHoverAct = ts('View Activity Record', array('domain' => 'org.civicrm.volunteer'));
     }
@@ -715,7 +715,7 @@ class CRM_Volunteer_Form_VolunteerReport extends CRM_Report_Form {
             $rows[$rowNum]['civicrm_contact_organization_organization_name_link'] = $url;
             $rows[$rowNum]['civicrm_contact_organization_organization_name_hover'] = $onHover;
           }
-          $entryFound = TRUE;
+          $entryFound = true;
         }
       }
 
@@ -729,7 +729,7 @@ class CRM_Volunteer_Form_VolunteerReport extends CRM_Report_Form {
             $rows[$rowNum]['civicrm_contact_contact_source_link'] = $url;
             $rows[$rowNum]['civicrm_contact_contact_source_hover'] = $onHover;
           }
-          $entryFound = TRUE;
+          $entryFound = true;
         }
       }
 
@@ -748,7 +748,7 @@ class CRM_Volunteer_Form_VolunteerReport extends CRM_Report_Form {
             }
             $rows[$rowNum]['civicrm_contact_contact_assignee'] = implode('; ', $link);
           }
-          $entryFound = TRUE;
+          $entryFound = true;
         }
       }
 
@@ -767,7 +767,7 @@ class CRM_Volunteer_Form_VolunteerReport extends CRM_Report_Form {
             }
             $rows[$rowNum]['civicrm_contact_contact_target'] = implode('; ', $link);
           }
-          $entryFound = TRUE;
+          $entryFound = true;
         }
       }
 
@@ -787,7 +787,7 @@ class CRM_Volunteer_Form_VolunteerReport extends CRM_Report_Form {
 
             $actionLinks = CRM_Activity_Selector_Activity::actionLinks($row['civicrm_activity_activity_type_id'],
               CRM_Utils_Array::value('civicrm_activity_source_record_id', $rows[$rowNum]),
-              FALSE,
+              false,
               $rows[$rowNum]['civicrm_activity_id']
             );
 
@@ -797,26 +797,26 @@ class CRM_Volunteer_Form_VolunteerReport extends CRM_Report_Form {
               'cxt' => $context,
             );
             $url = CRM_Utils_System::url($actionLinks[CRM_Core_Action::VIEW]['url'],
-              CRM_Core_Action::replace($actionLinks[CRM_Core_Action::VIEW]['qs'], $linkValues), TRUE
+              CRM_Core_Action::replace($actionLinks[CRM_Core_Action::VIEW]['qs'], $linkValues), true
             );
             $rows[$rowNum]['civicrm_activity_activity_type_id_link'] = $url;
             $rows[$rowNum]['civicrm_activity_activity_type_id_hover'] = $onHoverAct;
           }
-          $entryFound = TRUE;
+          $entryFound = true;
         }
       }
 
       if (array_key_exists('civicrm_activity_status_id', $row)) {
         if ($value = $row['civicrm_activity_status_id']) {
           $rows[$rowNum]['civicrm_activity_status_id'] = $activityStatus[$value];
-          $entryFound = TRUE;
+          $entryFound = true;
         }
       }
 
       if (array_key_exists('role_role', $row)) {
         if ($value = $row['role_role']) {
           $rows[$rowNum]['role_role'] = $volunteerRoles[$value];
-          $entryFound = TRUE;
+          $entryFound = true;
         }
       }
 
@@ -828,11 +828,11 @@ class CRM_Volunteer_Form_VolunteerReport extends CRM_Report_Form {
           $activityStatus[$row['civicrm_activity_status_id']] != 'Completed'
         ) {
           $rows[$rowNum]['class'] = "status-overdue";
-          $entryFound = TRUE;
+          $entryFound = true;
         }
       }
 
-      $entryFound = $this->alterDisplayAddressFields($row, $rows, $rowNum, 'activity', 'List all activities for this ') ? TRUE : $entryFound;
+      $entryFound = $this->alterDisplayAddressFields($row, $rows, $rowNum, 'activity', 'List all activities for this ') ? true : $entryFound;
 
       if (!$entryFound) {
         break;

--- a/CRM/Volunteer/Form/VolunteerSignUp.php
+++ b/CRM/Volunteer/Form/VolunteerSignUp.php
@@ -40,7 +40,7 @@ class CRM_Volunteer_Form_VolunteerSignUp extends CRM_Core_Form {
    *
    * @var boolean
    */
-  public $allowVolunteerSliderWidget = TRUE;
+  public $allowVolunteerSliderWidget = true;
 
   /**
    * The URL to which the user should be redirected after successfully
@@ -137,12 +137,12 @@ class CRM_Volunteer_Form_VolunteerSignUp extends CRM_Core_Form {
    * Info page associated with a Volunteer Project. See VOL-180 for more info.
    */
   function redirectLegacyRequests() {
-    $vid = CRM_Utils_Request::retrieve('vid', 'Int', $this, FALSE, NULL, 'GET');
+    $vid = CRM_Utils_Request::retrieve('vid', 'Int', $this, false, null, 'GET');
     
-    if($vid != NULL) {
+    if($vid != null) {
       $path = "civicrm/vol/";
       $fragment =  "/volunteer/opportunities?project=$vid&dest=event";
-      $newURL = CRM_Utils_System::url($path, NULL, FALSE, $fragment, FALSE, TRUE);
+      $newURL = CRM_Utils_System::url($path, null, false, $fragment, false, true);
       CRM_Utils_System::redirect($newURL);
     }    
   }
@@ -157,16 +157,16 @@ class CRM_Volunteer_Form_VolunteerSignUp extends CRM_Core_Form {
 
     CRM_Core_Resources::singleton()
         ->addScriptFile('org.civicrm.volunteer', 'js/CRM_Volunteer_Form_VolunteerSignUp.js')
-        ->addScriptFile('civicrm', 'packages/jquery/plugins/jquery.notify.min.js', -9990, 'html-header', FALSE);
+        ->addScriptFile('civicrm', 'packages/jquery/plugins/jquery.notify.min.js', -9990, 'html-header', false);
 
     $validNeedIds = array();
-    $needs = CRM_Utils_Request::retrieve('needs', 'String', $this, TRUE);
+    $needs = CRM_Utils_Request::retrieve('needs', 'String', $this, true);
     if (!is_array($needs)) {
       $needs = explode(',', $needs);
     }
 
     foreach($needs as $need) {
-      if (CRM_Utils_Type::validate($need, 'Positive', FALSE)) {
+      if (CRM_Utils_Type::validate($need, 'Positive', false)) {
         $validNeedIds[] = $need;
       }
     }
@@ -183,7 +183,7 @@ class CRM_Volunteer_Form_VolunteerSignUp extends CRM_Core_Form {
     $this->preProcessNeeds();
 
     $this->setDestination();
-    $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE);
+    $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, false);
 
     // current mode
     $this->_mode = ($this->_action == CRM_Core_Action::PREVIEW) ? 'test' : 'live';
@@ -352,7 +352,7 @@ class CRM_Volunteer_Form_VolunteerSignUp extends CRM_Core_Form {
       array(
         'type' => 'done',
         'name' => ts('Submit', array('domain' => 'org.civicrm.volunteer')),
-        'isDefault' => TRUE,
+        'isDefault' => true,
       ),
     ));
 
@@ -431,7 +431,7 @@ class CRM_Volunteer_Form_VolunteerSignUp extends CRM_Core_Form {
    * see http://wiki.civicrm.org/confluence/display/CRMDOC43/Transaction+Reference
    */
   function postProcess() {
-    $cid = CRM_Utils_Array::value('userID', $_SESSION['CiviCRM'], NULL);
+    $cid = CRM_Utils_Array::value('userID', $_SESSION['CiviCRM'], null);
     $values = $this->controller->exportValues();
 
     $profileFields = $this->getProfileFields($this->getPrimaryVolunteerProfileIDs());
@@ -576,7 +576,7 @@ class CRM_Volunteer_Form_VolunteerSignUp extends CRM_Core_Form {
     // Search for duplicate
     if (!$cid) {
       $dedupeParams = CRM_Dedupe_Finder::formatParams($profileValues, 'Individual');
-      $dedupeParams['check_permission'] = FALSE;
+      $dedupeParams['check_permission'] = false;
       $ids = CRM_Dedupe_Finder::dupesByParams($dedupeParams, 'Individual');
       if ($ids) {
         $cid = $ids[0];
@@ -600,9 +600,9 @@ class CRM_Volunteer_Form_VolunteerSignUp extends CRM_Core_Form {
    */
   function processAdditionalVolunteers(array $data) {
     $qty = CRM_Utils_Array::value('additionalVolunteerQuantity', $data, 0);
-    $qty = CRM_Utils_Type::validate($qty, 'Integer', FALSE);
+    $qty = CRM_Utils_Type::validate($qty, 'Integer', false);
 
-    if ($qty === NULL) {
+    if ($qty === null) {
       return;
     }
 
@@ -693,10 +693,10 @@ class CRM_Volunteer_Form_VolunteerSignUp extends CRM_Core_Form {
     $fieldList = array(); // master field list
 
     foreach($profileIds as $profileID) {
-      $fields = CRM_Core_BAO_UFGroup::getFields($profileID, FALSE, CRM_Core_Action::ADD,
-        NULL, NULL, FALSE, NULL,
-        FALSE, NULL, CRM_Core_Permission::CREATE,
-        'field_name', TRUE
+      $fields = CRM_Core_BAO_UFGroup::getFields($profileID, false, CRM_Core_Action::ADD,
+        null, null, false, null,
+        false, null, CRM_Core_Permission::CREATE,
+        'field_name', true
       );
 
       foreach ($fields as $key => $field) {
@@ -707,7 +707,7 @@ class CRM_Volunteer_Form_VolunteerSignUp extends CRM_Core_Form {
           $field,
           CRM_Profile_Form::MODE_CREATE,
           $contactID,
-          TRUE,
+          true,
           null,
           null,
           $prefix
@@ -746,9 +746,9 @@ class CRM_Volunteer_Form_VolunteerSignUp extends CRM_Core_Form {
    * after successfully submitting the sign-up form
    */
   protected function setDestination() {
-    $path = $query = $fragment = NULL;
+    $path = $query = $fragment = null;
 
-    $dest = CRM_Utils_Request::retrieve('dest', 'String', $this, FALSE);
+    $dest = CRM_Utils_Request::retrieve('dest', 'String', $this, false);
     switch ($dest) {
       case 'event':
         // If only one project is associated with the form, send the user back
@@ -766,7 +766,7 @@ class CRM_Volunteer_Form_VolunteerSignUp extends CRM_Core_Form {
         $fragment = '/volunteer/opportunities';
     }
 
-    $this->_destination = CRM_Utils_System::url($path, $query, FALSE, $fragment);
+    $this->_destination = CRM_Utils_System::url($path, $query, false, $fragment);
   }
 
   /**
@@ -777,7 +777,7 @@ class CRM_Volunteer_Form_VolunteerSignUp extends CRM_Core_Form {
     CRM_Utils_System::setTitle(ts('Please select a different volunteer opportunity', array('domain' => 'org.civicrm.volunteer')));
     $region = CRM_Core_Region::instance('page-body');
     $region->update('default', array(
-      'disabled' => TRUE,
+      'disabled' => true,
     ));
     $region->add(array(
       'template' => 'CRM/Volunteer/Form/Error.tpl',

--- a/CRM/Volunteer/Page/Roster.php
+++ b/CRM/Volunteer/Page/Roster.php
@@ -26,7 +26,7 @@ class CRM_Volunteer_Page_Roster extends CRM_Core_Page {
    * Builds the page.
    */
   public function run() {
-    $this->projectId = CRM_Utils_Request::retrieve('project_id', 'Positive', CRM_Core_DAO::$_nullObject, TRUE);
+    $this->projectId = CRM_Utils_Request::retrieve('project_id', 'Positive', CRM_Core_DAO::$_nullObject, true);
     $this->project = CRM_Volunteer_BAO_Project::retrieveByID($this->projectId);
     CRM_Utils_System::setTitle(ts('Volunteer Roster for %1', array(
       1 => $this->project->title,
@@ -94,7 +94,7 @@ class CRM_Volunteer_Page_Roster extends CRM_Core_Page {
   private function isAssignmentInThePast(array $assignment){
     // If we don't have the crucial data then we assume that it's not in the future.
     if (empty($assignment['start_time'])) {
-      return TRUE;
+      return true;
     }
 
     // In case there is no end time and no duration, we use the start date as

--- a/CRM/Volunteer/Page/Router.php
+++ b/CRM/Volunteer/Page/Router.php
@@ -2,7 +2,7 @@
 
 class CRM_Volunteer_Page_Router extends CRM_Core_Page {
 
-  function run($args = NULL) {
+  function run($args = null) {
     if (CRM_Utils_Array::value(0, $args) !== 'civicrm' || CRM_Utils_Array::value(1, $args) !== 'volunteer') {
       CRM_Core_Error::fatal('Invalid page callback config.');
       return;
@@ -27,12 +27,12 @@ class CRM_Volunteer_Page_Router extends CRM_Core_Page {
 
         // set params for controller
         $class = 'CRM_Profile_Form_Edit';
-        $title = NULL;
+        $title = null;
         $mode = isset($contact_id) ? CRM_Core_Action::UPDATE : CRM_Core_Action::ADD;
-        $imageUpload = FALSE;
-        $addSequence = FALSE;
-        $ignoreKey = TRUE;
-        $attachUpload = FALSE;
+        $imageUpload = false;
+        $addSequence = false;
+        $ignoreKey = true;
+        $attachUpload = false;
 
         $controller = new CRM_Core_Controller_Simple($class, $title, $mode, $imageUpload, $addSequence, $ignoreKey, $attachUpload);
 

--- a/CRM/Volunteer/Permission.php
+++ b/CRM/Volunteer/Permission.php
@@ -94,7 +94,7 @@ class CRM_Volunteer_Permission {
    * @return boolean
    *   TRUE is the action is allowed; else FALSE.
    */
-  public static function checkProjectPerms($op, $projectId = NULL) {
+  public static function checkProjectPerms($op, $projectId = null) {
     $opsRequiringProjectId = array(CRM_Core_Action::UPDATE, CRM_Core_Action::DELETE, self::VIEW_ROSTER,);
     if (in_array($op, $opsRequiringProjectId) && empty($projectId)) {
       CRM_Core_Error::fatal('Missing required parameter Project ID');
@@ -108,44 +108,44 @@ class CRM_Volunteer_Permission {
 
       case CRM_Core_Action::UPDATE:
         if (self::check('edit all volunteer projects')) {
-          return TRUE;
+          return true;
         }
 
         $projectOwners = CRM_Volunteer_BAO_Project::getContactsByRelationship($projectId, 'volunteer_owner');
         if (self::check('edit own volunteer projects')
           && in_array($contactId, $projectOwners)) {
-          return TRUE;
+          return true;
         }
         break;
       case CRM_Core_Action::DELETE:
         if (self::check('delete all volunteer projects')) {
-          return TRUE;
+          return true;
         }
 
         $projectOwners = CRM_Volunteer_BAO_Project::getContactsByRelationship($projectId, 'volunteer_owner');
         if (self::check('delete own volunteer projects')
           && in_array($contactId, $projectOwners)) {
-          return TRUE;
+          return true;
         }
         break;
       case CRM_Core_Action::VIEW:
         if (self::check('register to volunteer') || self::check('edit all volunteer projects')) {
-          return TRUE;
+          return true;
         }
         break;
       case self::VIEW_ROSTER:
         if (self::check('edit all volunteer projects')) {
-          return TRUE;
+          return true;
         }
 
         $projectManagers = CRM_Volunteer_BAO_Project::getContactsByRelationship($projectId, 'volunteer_manager');
         if (in_array($contactId, $projectManagers)) {
-          return TRUE;
+          return true;
         }
         break;
     }
 
-    return FALSE;
+    return false;
   }
 
 }

--- a/CRM/Volunteer/Upgrader.php
+++ b/CRM/Volunteer/Upgrader.php
@@ -79,7 +79,7 @@ class CRM_Volunteer_Upgrader extends CRM_Volunteer_Upgrader_Base {
       ));
     } catch (Exception $e) {
       $msg = 'Exception thrown in ' . __METHOD__ . '. Likely the option group already exists.';
-      CRM_Core_Error::debug_log_message($msg, FALSE, 'org.civicrm.volunteer');
+      CRM_Core_Error::debug_log_message($msg, false, 'org.civicrm.volunteer');
     }
 
     $optionDefaults = array(
@@ -273,7 +273,7 @@ class CRM_Volunteer_Upgrader extends CRM_Volunteer_Upgrader_Base {
       REFERENCES `civicrm_contact` (`id`)
       ON DELETE SET NULL
     ');
-    return TRUE;
+    return true;
   }
 
   /**
@@ -285,7 +285,7 @@ class CRM_Volunteer_Upgrader extends CRM_Volunteer_Upgrader_Base {
     $volContactTypeCustomGroupID = $this->createVolunteerContactCustomGroup();
     $customFieldId = $this->createVolunteerContactCustomFields($volContactTypeCustomGroupID);
     _volunteer_update_slider_fields(array(CRM_Core_Action::ADD => $customFieldId));
-    return TRUE;
+    return true;
   }
 
   /**
@@ -294,7 +294,7 @@ class CRM_Volunteer_Upgrader extends CRM_Volunteer_Upgrader_Base {
   public function upgrade_1401() {
     $this->ctx->log->info('Applying update 1401 - creating volunteer_interest profile');
     $this->executeCustomDataFileByAbsPath($this->extensionDir . '/xml/volunteer_interest_install.xml');
-    return TRUE;
+    return true;
   }
 
   // removed by VOL-91; do not reuse
@@ -306,7 +306,7 @@ class CRM_Volunteer_Upgrader extends CRM_Volunteer_Upgrader_Base {
   public function upgrade_1403() {
     $this->ctx->log->info('Applying update 1403 - creating commendation activity type and related custom fields');
     $this->installCommendationActivityType();
-    return TRUE;
+    return true;
   }
 
   /**
@@ -334,19 +334,19 @@ class CRM_Volunteer_Upgrader extends CRM_Volunteer_Upgrader_Base {
     $this->ctx->log->info('Applying update 2001 - Upgrading schema to 2.0');
     $this->schemaUpgrade20();
     $this->migrateProjectTitles();
-    return TRUE;
+    return true;
   }
 
   public function upgrade_2002() {
     $this->ctx->log->info('Applying update 2002 - Adding end_date to civicrm_volunteer_need');
     $this->addNeedEndDate();
-    return TRUE;
+    return true;
   }
 
   public function upgrade_2003() {
     $this->ctx->log->info('Applying update 2003 - Installing Volunteer message workflow templates');
     $this->installVolMsgWorkflowTpls();
-    return TRUE;
+    return true;
   }
 
   public function upgrade_2004() {
@@ -392,7 +392,7 @@ class CRM_Volunteer_Upgrader extends CRM_Volunteer_Upgrader_Base {
     $message = ts('This upgrade introduces two new permissions ("Edit Volunteer Project Relationships" and "Edit Volunteer Registration Profiles"). Grant these to allow users more control over the volunteer project create/edit workflow. Revoke them to streamline the process. Volunteer projects created by users lacking these privileges will use the defaults set by the system administrator.', array('domain' => 'org.civicrm.volunteer'));
     $title = ts('CiviVolunteer Upgrade Notice', array('domain' => 'org.civicrm.volunteer'));
     CRM_Core_Session::setStatus($message, $title, 'info', array('expires' => 0));
-    return TRUE;
+    return true;
   }
 
   /**
@@ -408,7 +408,7 @@ class CRM_Volunteer_Upgrader extends CRM_Volunteer_Upgrader_Base {
       CRM_Core_Session::setStatus($message, $title, 'info', array('expires' => 0));
     }
 
-    return TRUE;
+    return true;
   }
 
   /**
@@ -420,7 +420,7 @@ class CRM_Volunteer_Upgrader extends CRM_Volunteer_Upgrader_Base {
     $message = ts("Some users have reported that their CiviVolunteer settings \"disappear\" after an upgrade. This is due to an issue with CiviCRM's extension system, but can usually be resolved by flushing CiviCRM's caches. For more information, see <a href=\"https://issues.civicrm.org/jira/browse/CRM-21210\">CRM-21210</a>.", array('domain' => 'org.civicrm.volunteer'));
     $title = ts('Post-Upgrade Steps May Be Required', array('domain' => 'org.civicrm.volunteer'));
     CRM_Core_Session::setStatus($message, $title, 'info', array('expires' => 0));
-    return TRUE;
+    return true;
   }
 
   private function installNeedMetaDateFields() {
@@ -575,8 +575,8 @@ class CRM_Volunteer_Upgrader extends CRM_Volunteer_Upgrader_Base {
    * @return int ID of Activity type (i.e., the value of the OptionValue)
    * @throws CRM_Core_Exception
    */
-  public function createActivityType($machineName, $label = NULL) {
-    $id = NULL;
+  public function createActivityType($machineName, $label = null) {
+    $id = null;
     $optionGroup = civicrm_api3('OptionGroup', 'getsingle', array(
       'name' => 'activity_type',
       'return' => 'id'
@@ -601,8 +601,8 @@ class CRM_Volunteer_Upgrader extends CRM_Volunteer_Upgrader_Base {
         'version' => 3,
         'weight' => 0,
       ));
-      if (CRM_Utils_Array::value('is_error', $result, FALSE)) {
-        CRM_Core_Error::debug_var('activityTypeResult', $result, TRUE, TRUE, 'org.civicrm.volunteer');
+      if (CRM_Utils_Array::value('is_error', $result, false)) {
+        CRM_Core_Error::debug_var('activityTypeResult', $result, true, true, 'org.civicrm.volunteer');
         throw new CRM_Core_Exception('Failed to register activity type ' . $machineName);
       }
       $id = $result['values'][$result['id']]['value'];
@@ -619,7 +619,7 @@ class CRM_Volunteer_Upgrader extends CRM_Volunteer_Upgrader_Base {
    * @throws CRM_Core_Exception
    */
   public function createVolunteerContactType() {
-    $id = NULL;
+    $id = null;
     $get = civicrm_api3('ContactType', 'get', array(
       'name' => self::customContactTypeName,
       'return' => 'id',
@@ -638,7 +638,7 @@ class CRM_Volunteer_Upgrader extends CRM_Volunteer_Upgrader_Base {
          )),
       ));
       if (CRM_Utils_Array::value('is_error', $create)) {
-        CRM_Core_Error::debug_var('contactTypeResult', $create, TRUE, TRUE, 'org.civicrm.volunteer');
+        CRM_Core_Error::debug_var('contactTypeResult', $create, true, true, 'org.civicrm.volunteer');
         throw new CRM_Core_Exception('Failed to register contact type');
       }
 
@@ -656,7 +656,7 @@ class CRM_Volunteer_Upgrader extends CRM_Volunteer_Upgrader_Base {
    * @throws CRM_Core_Exception
    */
   public function createVolunteerContactCustomGroup() {
-    $id = NULL;
+    $id = null;
     $get = civicrm_api3('CustomGroup', 'get', array(
       'name' => self::customContactGroupName,
       'return' => 'id',
@@ -673,7 +673,7 @@ class CRM_Volunteer_Upgrader extends CRM_Volunteer_Upgrader_Base {
         'title' => ts('Volunteer Information', array('domain' => 'org.civicrm.volunteer')),
       ));
       if (CRM_Utils_Array::value('is_error', $create)) {
-        CRM_Core_Error::debug_var('customGroupResult', $create, TRUE, TRUE, 'org.civicrm.volunteer');
+        CRM_Core_Error::debug_var('customGroupResult', $create, true, true, 'org.civicrm.volunteer');
         throw new CRM_Core_Exception('Failed to register custom group for volunteer subtype');
       }
 
@@ -777,7 +777,7 @@ class CRM_Volunteer_Upgrader extends CRM_Volunteer_Upgrader_Base {
           ts('Field already exists', array('domain' => 'org.civicrm.volunteer'))
         );
       } else {
-        CRM_Core_Error::debug_var('apiResult', $apiResult, TRUE, TRUE, 'org.civicrm.volunteer');
+        CRM_Core_Error::debug_var('apiResult', $apiResult, true, true, 'org.civicrm.volunteer');
         throw new CRM_Core_Exception("Failed to create $entityType.");
       }
     }
@@ -818,8 +818,8 @@ class CRM_Volunteer_Upgrader extends CRM_Volunteer_Upgrader_Base {
         );
         $result = civicrm_api('OptionValue', 'create', $params);
 
-        if (CRM_Utils_Array::value('is_error', $result, FALSE)) {
-          CRM_Core_Error::debug_var('activityStatusResult', $result, TRUE, TRUE, 'org.civicrm.volunteer');
+        if (CRM_Utils_Array::value('is_error', $result, false)) {
+          CRM_Core_Error::debug_var('activityStatusResult', $result, true, true, 'org.civicrm.volunteer');
           throw new CRM_Core_Exception('Failed to register activity status');
         }
       }
@@ -834,7 +834,7 @@ class CRM_Volunteer_Upgrader extends CRM_Volunteer_Upgrader_Base {
       require_once 'CRM/Utils/Migrate/Import.php';
       $import = new CRM_Utils_Migrate_Import();
       $import->runXmlElement($xml);
-      return TRUE;
+      return true;
   }
 
   /**

--- a/CRM/Volunteer/Upgrader/Base.php
+++ b/CRM/Volunteer/Upgrader/Base.php
@@ -36,7 +36,7 @@ class CRM_Volunteer_Upgrader_Base {
    * @var boolean
    *   Flag to clean up extension revision data in civicrm_setting
    */
-  private $revisionStorageIsDeprecated = FALSE;
+  private $revisionStorageIsDeprecated = false;
 
   /**
    * Obtain a reference to the active upgrade handler.
@@ -100,7 +100,7 @@ class CRM_Volunteer_Upgrader_Base {
     require_once 'CRM/Utils/Migrate/Import.php';
     $import = new CRM_Utils_Migrate_Import();
     $import->run($xml_file);
-    return TRUE;
+    return true;
   }
 
   /**
@@ -115,7 +115,7 @@ class CRM_Volunteer_Upgrader_Base {
       CIVICRM_DSN,
       $this->extensionDir . DIRECTORY_SEPARATOR . $relativePath
     );
-    return TRUE;
+    return true;
   }
 
   /**
@@ -132,9 +132,9 @@ class CRM_Volunteer_Upgrader_Base {
     $smarty = CRM_Core_Smarty::singleton();
     $smarty->assign('domainID', CRM_Core_Config::domainID());
     CRM_Utils_File::sourceSQLFile(
-      CIVICRM_DSN, $smarty->fetch($tplFile), NULL, TRUE
+      CIVICRM_DSN, $smarty->fetch($tplFile), null, true
     );
-    return TRUE;
+    return true;
   }
 
   /**
@@ -147,7 +147,7 @@ class CRM_Volunteer_Upgrader_Base {
   public function executeSql($query, $params = array()) {
     // FIXME verify that we raise an exception on error
     CRM_Core_DAO::executeQuery($query, $params);
-    return TRUE;
+    return true;
   }
 
   /**
@@ -182,10 +182,10 @@ class CRM_Volunteer_Upgrader_Base {
     $currentRevision = $this->getCurrentRevision();
 
     if (empty($revisions)) {
-      return FALSE;
+      return false;
     }
     if (empty($currentRevision)) {
-      return TRUE;
+      return true;
     }
 
     return ($currentRevision < max($revisions));
@@ -257,7 +257,7 @@ class CRM_Volunteer_Upgrader_Base {
   private function getCurrentRevisionDeprecated() {
     $key = $this->extensionName . ':version';
     if ($revision = CRM_Core_BAO_Setting::getItem('Extension', $key)) {
-      $this->revisionStorageIsDeprecated = TRUE;
+      $this->revisionStorageIsDeprecated = true;
     }
     return $revision;
   }
@@ -266,7 +266,7 @@ class CRM_Volunteer_Upgrader_Base {
     CRM_Core_BAO_Extension::setSchemaVersion($this->extensionName, $revision);
     // clean up legacy schema version store (CRM-19252)
     $this->deleteDeprecatedRevision();
-    return TRUE;
+    return true;
   }
 
   private function deleteDeprecatedRevision() {
@@ -361,7 +361,7 @@ class CRM_Volunteer_Upgrader_Base {
     }
   }
 
-  public function onUpgrade($op, CRM_Queue_Queue $queue = NULL) {
+  public function onUpgrade($op, CRM_Queue_Queue $queue = null) {
     switch ($op) {
       case 'check':
         return array($this->hasPendingRevisions());

--- a/api/v3/VolunteerNeed.php
+++ b/api/v3/VolunteerNeed.php
@@ -96,7 +96,7 @@ function civicrm_api3_volunteer_need_get($params) {
         $need['role_description'] = $role['description'];
       } elseif (CRM_Utils_Array::value('is_flexible', $need)) {
         $need['role_label'] = CRM_Volunteer_BAO_Need::getFlexibleRoleLabel();
-        $need['role_description'] = NULL;
+        $need['role_description'] = null;
       }
     }
   }

--- a/api/v3/VolunteerUtil.php
+++ b/api/v3/VolunteerUtil.php
@@ -155,7 +155,7 @@ function civicrm_api3_volunteer_util_getsupportingdata($params) {
     ));
     $results['relationship_types'] = $relTypes['values'];
 
-    $results['phone_types'] = CRM_Core_OptionGroup::values("phone_type", FALSE, FALSE, TRUE);
+    $results['phone_types'] = CRM_Core_OptionGroup::values("phone_type", false, false, true);
     $results['volunteer_general_project_settings_help_text'] = civicrm_api3('Setting', 'getvalue', array(
       'name' => "volunteer_general_project_settings_help_text",
     ));
@@ -170,7 +170,7 @@ function civicrm_api3_volunteer_util_getsupportingdata($params) {
   }
 
   if ($controller === 'VolOppsCtrl') {
-    $results['roles'] = CRM_Core_OptionGroup::values('volunteer_role', FALSE, FALSE, TRUE);
+    $results['roles'] = CRM_Core_OptionGroup::values('volunteer_role', false, false, true);
   }
 
   $results['use_profile_editor'] = CRM_Volunteer_Permission::check(array("access CiviCRM","profile listings and forms"));

--- a/settings/volunteer.setting.php
+++ b/settings/volunteer.setting.php
@@ -6,7 +6,7 @@ return array(
     'group' => 'org.civicrm.volunteer',
     'name' => 'slider_widget_fields',
     'type' => 'Array',
-    'default' => NULL,
+    'default' => null,
     'add' => '4.5',
     'is_domain' => 1,
     'is_contact' => 0,

--- a/tests/phpunit/CRM/Volunteer/BAO/AssignmentTest.php
+++ b/tests/phpunit/CRM/Volunteer/BAO/AssignmentTest.php
@@ -35,7 +35,7 @@ class CRM_Volunteer_BAO_AssignmentTest extends VolunteerTestAbstract {
    * that the project beneficiary is made the activity target.
    */
   function testActivityTarget() {
-    $beneficiaryContactId = $need = $project = $volunteerContactId = NULL;
+    $beneficiaryContactId = $need = $project = $volunteerContactId = null;
     extract($this->setUpProject(), EXTR_IF_EXISTS);
 
     $projectContact = CRM_Core_DAO::createTestObject('CRM_Volunteer_BAO_ProjectContact', array(
@@ -66,7 +66,7 @@ class CRM_Volunteer_BAO_AssignmentTest extends VolunteerTestAbstract {
    * that the activity subject defaults to the project title.
    */
   function testActivitySubject() {
-    $need = $project = $volunteerContactId = NULL;
+    $need = $project = $volunteerContactId = null;
     extract($this->setUpProject(), EXTR_IF_EXISTS);
 
     $assignmentId = CRM_Volunteer_BAO_Assignment::createVolunteerActivity(array(
@@ -110,7 +110,7 @@ class CRM_Volunteer_BAO_AssignmentTest extends VolunteerTestAbstract {
       'source_contact_id' => 1,
       'volunteer_need_id' => $need->id,
     ));
-    $this->assertNotSame(FALSE, $activityId, 'Failed to create Volunteer Activity');
+    $this->assertNotSame(false, $activityId, 'Failed to create Volunteer Activity');
 
     $createdActivity = CRM_Volunteer_BAO_Assignment::findById($activityId);
     $this->assertEquals($campaign->id, $createdActivity->campaign_id,

--- a/tests/phpunit/CRM/Volunteer/BAO/ProjectTest.php
+++ b/tests/phpunit/CRM/Volunteer/BAO/ProjectTest.php
@@ -38,7 +38,7 @@ class CRM_Volunteer_BAO_ProjectTest extends VolunteerTestAbstract {
    * Test helper method isOff, which should return TRUE passed an "off" value
    */
   function testProjectIsOff() {
-    $this->assertTrue(CRM_Volunteer_BAO_Project::isOff(FALSE));
+    $this->assertTrue(CRM_Volunteer_BAO_Project::isOff(false));
     $this->assertTrue(CRM_Volunteer_BAO_Project::isOff(0));
     $this->assertTrue(CRM_Volunteer_BAO_Project::isOff('0'));
   }

--- a/tests/phpunit/api/v3/VolunteerNeedTest.php
+++ b/tests/phpunit/api/v3/VolunteerNeedTest.php
@@ -75,7 +75,7 @@ class api_v3_VolunteerNeedTest extends VolunteerTestAbstract {
     ) + $defaultNeedParams);
     $singleDateNeedProject1 = $this->callAPISuccess('VolunteerNeed', 'create', array(
       'project_id' => $project1['id'],
-      'end_time' => NULL,
+      'end_time' => null,
     ) + $defaultNeedParams);
     $disabledNeedProject1 = $this->callAPISuccess('VolunteerNeed', 'create', array(
       'project_id' => $project1['id'],

--- a/volunteer.civix.php
+++ b/volunteer.civix.php
@@ -26,7 +26,7 @@ class CRM_Volunteer_ExtensionUtil {
    */
   public static function ts($text, $params = array()) {
     if (!array_key_exists('domain', $params)) {
-      $params['domain'] = array(self::LONG_NAME, NULL);
+      $params['domain'] = array(self::LONG_NAME, null);
     }
     return ts($text, $params);
   }
@@ -41,8 +41,8 @@ class CRM_Volunteer_ExtensionUtil {
    *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
    *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
    */
-  public static function url($file = NULL) {
-    if ($file === NULL) {
+  public static function url($file = null) {
+    if ($file === null) {
       return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
     }
     return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
@@ -58,9 +58,9 @@ class CRM_Volunteer_ExtensionUtil {
    *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo'.
    *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
    */
-  public static function path($file = NULL) {
+  public static function path($file = null) {
     // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
-    return __DIR__ . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
+    return __DIR__ . ($file === null ? '' : (DIRECTORY_SEPARATOR . $file));
   }
 
   /**
@@ -84,12 +84,12 @@ use CRM_Volunteer_ExtensionUtil as E;
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_config
  */
-function _volunteer_civix_civicrm_config(&$config = NULL) {
-  static $configured = FALSE;
+function _volunteer_civix_civicrm_config(&$config = null) {
+  static $configured = false;
   if ($configured) {
     return;
   }
-  $configured = TRUE;
+  $configured = true;
 
   $template =& CRM_Core_Smarty::singleton();
 
@@ -198,7 +198,7 @@ function _volunteer_civix_civicrm_disable() {
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_upgrade
  */
-function _volunteer_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
+function _volunteer_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = null) {
   if ($upgrader = _volunteer_civix_upgrader()) {
     return $upgrader->onUpgrade($op, $queue);
   }
@@ -209,7 +209,7 @@ function _volunteer_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
  */
 function _volunteer_civix_upgrader() {
   if (!file_exists(__DIR__ . '/CRM/Volunteer/Upgrader.php')) {
-    return NULL;
+    return null;
   }
   else {
     return CRM_Volunteer_Upgrader_Base::instance();
@@ -241,7 +241,7 @@ function _volunteer_civix_find_files($dir, $pattern) {
       }
     }
     if ($dh = opendir($subdir)) {
-      while (FALSE !== ($entry = readdir($dh))) {
+      while (false !== ($entry = readdir($dh))) {
         $path = $subdir . DIRECTORY_SEPARATOR . $entry;
         if ($entry{0} == '.') {
         }
@@ -366,11 +366,11 @@ function _volunteer_civix_insert_navigation_menu(&$menu, $path, $item) {
         'active'     => 1,
       ), $item),
     );
-    return TRUE;
+    return true;
   }
   else {
     // Find an recurse into the next level down
-    $found = FALSE;
+    $found = false;
     $path = explode('/', $path);
     $first = array_shift($path);
     foreach ($menu as $key => &$entry) {
@@ -405,13 +405,13 @@ function _volunteer_civix_fixNavigationMenu(&$nodes) {
       $maxNavID = max($maxNavID, $item);
     }
   });
-  _volunteer_civix_fixNavigationMenuItems($nodes, $maxNavID, NULL);
+  _volunteer_civix_fixNavigationMenuItems($nodes, $maxNavID, null);
 }
 
 function _volunteer_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) {
   $origKeys = array_keys($nodes);
   foreach ($origKeys as $origKey) {
-    if (!isset($nodes[$origKey]['attributes']['parentID']) && $parentID !== NULL) {
+    if (!isset($nodes[$origKey]['attributes']['parentID']) && $parentID !== null) {
       $nodes[$origKey]['attributes']['parentID'] = $parentID;
     }
     // If no navID, then assign navID and fix key.
@@ -433,12 +433,12 @@ function _volunteer_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID)
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterSettingsFolders
  */
-function _volunteer_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  static $configured = FALSE;
+function _volunteer_civix_civicrm_alterSettingsFolders(&$metaDataFolders = null) {
+  static $configured = false;
   if ($configured) {
     return;
   }
-  $configured = TRUE;
+  $configured = true;
 
   $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
   if (is_dir($settingsDir) && !in_array($settingsDir, $metaDataFolders)) {

--- a/volunteer.php
+++ b/volunteer.php
@@ -44,12 +44,12 @@ function volunteer_civicrm_config(&$config) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_navigationMenu/
  */
 function volunteer_civicrm_navigationMenu(&$menu) {
-  _volunteer_civix_insert_navigation_menu($menu, NULL, array(
+  _volunteer_civix_insert_navigation_menu($menu, null, array(
     'label' => E::ts('Volunteers'),
     'name' => 'volunteer_volunteers',
-    'url' => NULL,
-    'permission' => NULL,
-    'operator' => NULL,
+    'url' => null,
+    'permission' => null,
+    'operator' => null,
     'separator' => 0,
     'icon' => 'crm-i fa-users',
   ));
@@ -58,8 +58,8 @@ function volunteer_civicrm_navigationMenu(&$menu) {
     'label' => E::ts('New Volunteer Project'),
     'name' => 'volunteer_new_project',
     'url' => 'civicrm/vol/#/volunteer/manage/0',
-    'permission' => NULL,
-    'operator' => NULL,
+    'permission' => null,
+    'operator' => null,
     'separator' => 0,
   ));
 
@@ -67,8 +67,8 @@ function volunteer_civicrm_navigationMenu(&$menu) {
     'label' => E::ts('Manage Volunteer Projects'),
     'name' => 'volunteer_manage_projects',
     'url' => 'civicrm/vol/#/volunteer/manage',
-    'permission' => NULL,
-    'operator' => NULL,
+    'permission' => null,
+    'operator' => null,
     'separator' => 1,
   ));
 
@@ -76,8 +76,8 @@ function volunteer_civicrm_navigationMenu(&$menu) {
     'label' => E::ts('Configure Roles'),
     'name' => 'volunteer_config_roles',
     'url' => 'civicrm/admin/options/volunteer_role?reset=1',
-    'permission' => NULL,
-    'operator' => NULL,
+    'permission' => null,
+    'operator' => null,
     'separator' => 0,
   ));
 
@@ -85,8 +85,8 @@ function volunteer_civicrm_navigationMenu(&$menu) {
     'label' => E::ts('Configure Project Relationships'),
     'name' => 'volunteer_config_projrel',
     'url' => 'civicrm/admin/options/volunteer_project_relationship?reset=1',
-    'permission' => NULL,
-    'operator' => NULL,
+    'permission' => null,
+    'operator' => null,
     'separator' => 0,
   ));
 
@@ -94,8 +94,8 @@ function volunteer_civicrm_navigationMenu(&$menu) {
     'label' => E::ts('Configure Volunteer Settings'),
     'name' => 'volunteer_config_settings',
     'url' => 'civicrm/admin/volunteer/settings',
-    'permission' => NULL,
-    'operator' => NULL,
+    'permission' => null,
+    'operator' => null,
     'separator' => 1,
   ));
 
@@ -103,8 +103,8 @@ function volunteer_civicrm_navigationMenu(&$menu) {
     'label' => E::ts('Volunteer Interest Form'),
     'name' => 'volunteer_join',
     'url' => 'civicrm/volunteer/join',
-    'permission' => NULL,
-    'operator' => NULL,
+    'permission' => null,
+    'operator' => null,
     'separator' => 0,
   ));
 
@@ -112,8 +112,8 @@ function volunteer_civicrm_navigationMenu(&$menu) {
     'label' => E::ts('Search for Volunteer Opportunities'),
     'name' => 'volunteer_opp_search',
     'url' => 'civicrm/vol/#/volunteer/opportunities',
-    'permission' => NULL,
-    'operator' => NULL,
+    'permission' => null,
+    'operator' => null,
     'separator' => 0,
   ));
 
@@ -125,7 +125,7 @@ function volunteer_civicrm_navigationMenu(&$menu) {
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterSettingsFolders
  */
-function volunteer_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
+function volunteer_civicrm_alterSettingsFolders(&$metaDataFolders = null) {
   _volunteer_civix_civicrm_alterSettingsFolders($metaDataFolders);
 }
 
@@ -166,14 +166,14 @@ function volunteer_civicrm_tabset($tabsetName, &$tabs, $context) {
       $tab['volunteer'] = array(
         'title' => ts('Volunteers', array('domain' => 'org.civicrm.volunteer')),
         'link' => $url,
-        'valid' => TRUE,
-        'active' => TRUE,
+        'valid' => true,
+        'active' => true,
         'class' => 'livePage',
         'current' => false,
       );
 
       if (!CRM_Volunteer_BAO_Project::isActive($eventId, CRM_Event_DAO_Event::$_tableName)) {
-        $tab['volunteer']['valid'] = FALSE;
+        $tab['volunteer']['valid'] = false;
       }
     }
     else {
@@ -254,7 +254,7 @@ function volunteer_civicrm_disable() {
  * @return mixed  based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
  *                for 'enqueue', returns void
  */
-function volunteer_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
+function volunteer_civicrm_upgrade($op, CRM_Queue_Queue $queue = null) {
   return _volunteer_civix_civicrm_upgrade($op, $queue);
 }
 
@@ -371,11 +371,11 @@ function _volunteer_civicrm_pageRun_CRM_Event_Page_EventInfo(&$page) {
         //VOL-190: Hide search pane in "shopping cart" for low role count projects
         $hideSearch = ($openNeeds['count'] < 10) ? "hideSearch=always" : (($openNeeds['count'] < 25) ? "hideSearch=1" : "hideSearch=0");
         $url = CRM_Utils_System::url('civicrm/vol/',
-          NULL, // query string
-          FALSE, // absolute?
+          null, // query string
+          false, // absolute?
           "/volunteer/opportunities?project={$project->id}&dest=event&{$hideSearch}", // fragment
-          TRUE, // htmlize?
-          TRUE // is frontend?
+          true, // htmlize?
+          true // is frontend?
         );
       }
 
@@ -433,7 +433,7 @@ function _volunteer_civicrm_buildForm_CRM_Activity_Form_Activity($formName, &$fo
     'custom_' . $field_id . '_1',
     'custom_' . $field_id . '_-1',
   );
-  $element_name = NULL;
+  $element_name = null;
   foreach ($possible_element_names as $name) {
     if ($form->elementExists($name)) {
       $element_name = $name;
@@ -466,7 +466,7 @@ function _volunteer_civicrm_buildForm_CRM_Activity_Form_Activity($formName, &$fo
         $element_name,          // field name
         $field->_label,         // field label
         $needs,                 // list of options (value => label)
-        TRUE                    // required
+        true                    // required
       );
     }
   }
@@ -516,7 +516,7 @@ function volunteer_civicrm_alterAPIPermissions($entity, $action, &$params, &$per
 
   // allow fairly liberal access to the volunteer opp listing UI, which uses lots of API calls
   if (_volunteer_isVolListingApiCall($entity, $action) && CRM_Volunteer_Permission::checkProjectPerms(CRM_Core_Action::VIEW)) {
-    $params['check_permissions'] = FALSE;
+    $params['check_permissions'] = false;
   }
 }
 

--- a/volunteer.slider.php
+++ b/volunteer.slider.php
@@ -43,7 +43,7 @@ function _volunteer_civicrm_postProcess_CRM_Custom_Form_Field($formName, &$form)
  * Registers the form to allow use of the volunteer slider widget.
  */
 function _volunteer_civicrm_buildForm_CRM_Profile_Form_Edit($formName, CRM_Core_Form &$form) {
-  $form->allowVolunteerSliderWidget = TRUE;
+  $form->allowVolunteerSliderWidget = true;
 }
 
 /**


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!

See also,
https://github.com/civicrm/civicrm-wordpress/pull/149
https://github.com/civicrm/civicrm-drupal/pull/570