### PR TITLE
Change PHP keywords to comply with Drupal

### DIFF
--- a/CRM/Volunteer/DAO/Need.php
+++ b/CRM/Volunteer/DAO/Need.php
@@ -49,7 +49,7 @@ class CRM_Volunteer_DAO_Need extends CRM_Core_DAO {
    *
    * @var boolean
    */
-  static $_log = true;
+  static $_log = TRUE;
   /**
    * Need Id
    *
@@ -153,7 +153,7 @@ class CRM_Volunteer_DAO_Need extends CRM_Core_DAO {
           'type' => CRM_Utils_Type::T_INT,
           'title' => ts('CiviVolunteer Need ID', array('domain' => 'org.civicrm.volunteer')) ,
           'description' => 'Need Id',
-          'required' => true,
+          'required' => TRUE,
           'table_name' => 'civicrm_volunteer_need',
           'entity' => 'Need',
           'bao' => 'CRM_Volunteer_DAO_Need',
@@ -162,7 +162,7 @@ class CRM_Volunteer_DAO_Need extends CRM_Core_DAO {
           'name' => 'project_id',
           'type' => CRM_Utils_Type::T_INT,
           'description' => 'FK to civicrm_volunteer_project table which contains entity_table + entity for each volunteer project (initially civicrm_event + eventID).',
-          'required' => false,
+          'required' => FALSE,
           'table_name' => 'civicrm_volunteer_need',
           'entity' => 'Need',
           'bao' => 'CRM_Volunteer_DAO_Need',
@@ -199,7 +199,7 @@ class CRM_Volunteer_DAO_Need extends CRM_Core_DAO {
           'type' => CRM_Utils_Type::T_BOOLEAN,
           'title' => ts('Flexible', array('domain' => 'org.civicrm.volunteer')) ,
           'description' => 'Boolean indicating whether or not the time and role are flexible. Activities linked to a flexible need indicate that the volunteer is generally available.',
-          'required' => true,
+          'required' => TRUE,
           'table_name' => 'civicrm_volunteer_need',
           'entity' => 'Need',
           'bao' => 'CRM_Volunteer_DAO_Need',
@@ -247,7 +247,7 @@ class CRM_Volunteer_DAO_Need extends CRM_Core_DAO {
           'type' => CRM_Utils_Type::T_BOOLEAN,
           'title' => ts('Enabled', array('domain' => 'org.civicrm.volunteer')) ,
           'description' => 'Is this need enabled?',
-          'required' => true,
+          'required' => TRUE,
           'default' => '1',
           'table_name' => 'civicrm_volunteer_need',
           'entity' => 'Need',
@@ -311,7 +311,7 @@ class CRM_Volunteer_DAO_Need extends CRM_Core_DAO {
    *
    * @return array
    */
-  static function &import($prefix = false) {
+  static function &import($prefix = FALSE) {
     $r = CRM_Core_DAO_AllCoreTables::getImports(__CLASS__, 'volunteer_need', $prefix, array());
     return $r;
   }
@@ -322,7 +322,7 @@ class CRM_Volunteer_DAO_Need extends CRM_Core_DAO {
    *
    * @return array
    */
-  static function &export($prefix = false) {
+  static function &export($prefix = FALSE) {
     $r = CRM_Core_DAO_AllCoreTables::getExports(__CLASS__, 'volunteer_need', $prefix, array());
     return $r;
   }

--- a/CRM/Volunteer/DAO/Project.php
+++ b/CRM/Volunteer/DAO/Project.php
@@ -49,7 +49,7 @@ class CRM_Volunteer_DAO_Project extends CRM_Core_DAO {
    *
    * @var boolean
    */
-  static $_log = true;
+  static $_log = TRUE;
   /**
    * Project Id
    *
@@ -133,7 +133,7 @@ class CRM_Volunteer_DAO_Project extends CRM_Core_DAO {
           'type' => CRM_Utils_Type::T_INT,
           'title' => ts('CiviVolunteer Project ID', array('domain' => 'org.civicrm.volunteer')) ,
           'description' => 'Project Id',
-          'required' => true,
+          'required' => TRUE,
           'table_name' => 'civicrm_volunteer_project',
           'entity' => 'Project',
           'bao' => 'CRM_Volunteer_DAO_Project',
@@ -143,7 +143,7 @@ class CRM_Volunteer_DAO_Project extends CRM_Core_DAO {
           'type' => CRM_Utils_Type::T_STRING,
           'title' => ts('Title', array('domain' => 'org.civicrm.volunteer')) ,
           'description' => 'The title of the Volunteer Project',
-          'required' => true,
+          'required' => TRUE,
           'maxlength' => 255,
           'size' => CRM_Utils_Type::HUGE,
           'table_name' => 'civicrm_volunteer_project',
@@ -155,7 +155,7 @@ class CRM_Volunteer_DAO_Project extends CRM_Core_DAO {
           'type' => CRM_Utils_Type::T_TEXT,
           'title' => ts('Description', array('domain' => 'org.civicrm.volunteer')) ,
           'description' => 'Full description of the Volunteer Project. Text and HTML allowed. Displayed on sign-up screens.',
-          'required' => false,
+          'required' => FALSE,
           'rows' => 8,
           'cols' => 60,
           'table_name' => 'civicrm_volunteer_project',
@@ -170,7 +170,7 @@ class CRM_Volunteer_DAO_Project extends CRM_Core_DAO {
           'type' => CRM_Utils_Type::T_STRING,
           'title' => ts('Entity Table', array('domain' => 'org.civicrm.volunteer')) ,
           'description' => 'Entity table for entity_id (initially civicrm_event)',
-          'required' => true,
+          'required' => TRUE,
           'maxlength' => 64,
           'size' => CRM_Utils_Type::BIG,
           'table_name' => 'civicrm_volunteer_project',
@@ -181,7 +181,7 @@ class CRM_Volunteer_DAO_Project extends CRM_Core_DAO {
           'name' => 'entity_id',
           'type' => CRM_Utils_Type::T_INT,
           'description' => 'Implicit FK project entity (initially eventID).',
-          'required' => true,
+          'required' => TRUE,
           'table_name' => 'civicrm_volunteer_project',
           'entity' => 'Project',
           'bao' => 'CRM_Volunteer_DAO_Project',
@@ -191,7 +191,7 @@ class CRM_Volunteer_DAO_Project extends CRM_Core_DAO {
           'type' => CRM_Utils_Type::T_BOOLEAN,
           'title' => ts('Enabled', array('domain' => 'org.civicrm.volunteer')) ,
           'description' => 'Is this need enabled?',
-          'required' => true,
+          'required' => TRUE,
           'default' => '1',
           'table_name' => 'civicrm_volunteer_project',
           'entity' => 'Project',
@@ -212,7 +212,7 @@ class CRM_Volunteer_DAO_Project extends CRM_Core_DAO {
           'type' => CRM_Utils_Type::T_INT,
           'title' => ts('Campaign', array('domain' => 'org.civicrm.volunteer')) ,
           'description' => 'The campaign associated with this Volunteer Project.',
-          'required' => false,
+          'required' => FALSE,
           'table_name' => 'civicrm_volunteer_project',
           'entity' => 'Project',
           'bao' => 'CRM_Volunteer_DAO_Project',
@@ -258,7 +258,7 @@ class CRM_Volunteer_DAO_Project extends CRM_Core_DAO {
    *
    * @return array
    */
-  static function &import($prefix = false) {
+  static function &import($prefix = FALSE) {
     $r = CRM_Core_DAO_AllCoreTables::getImports(__CLASS__, 'volunteer_project', $prefix, array());
     return $r;
   }
@@ -269,7 +269,7 @@ class CRM_Volunteer_DAO_Project extends CRM_Core_DAO {
    *
    * @return array
    */
-  static function &export($prefix = false) {
+  static function &export($prefix = FALSE) {
     $r = CRM_Core_DAO_AllCoreTables::getExports(__CLASS__, 'volunteer_project', $prefix, array());
     return $r;
   }

--- a/CRM/Volunteer/DAO/ProjectContact.php
+++ b/CRM/Volunteer/DAO/ProjectContact.php
@@ -49,7 +49,7 @@ class CRM_Volunteer_DAO_ProjectContact extends CRM_Core_DAO {
    *
    * @var boolean
    */
-  static $_log = true;
+  static $_log = TRUE;
   /**
    *
    * @var int unsigned
@@ -107,7 +107,7 @@ class CRM_Volunteer_DAO_ProjectContact extends CRM_Core_DAO {
           'name' => 'id',
           'type' => CRM_Utils_Type::T_INT,
           'title' => ts('CiviVolunteer ProjectContact Row ID', array('domain' => 'org.civicrm.volunteer')) ,
-          'required' => true,
+          'required' => TRUE,
           'table_name' => 'civicrm_volunteer_project_contact',
           'entity' => 'ProjectContact',
           'bao' => 'CRM_Volunteer_DAO_ProjectContact',
@@ -117,7 +117,7 @@ class CRM_Volunteer_DAO_ProjectContact extends CRM_Core_DAO {
           'type' => CRM_Utils_Type::T_INT,
           'title' => ts('CiviVolunteer Project ID', array('domain' => 'org.civicrm.volunteer')) ,
           'description' => 'Foreign key to the Volunteer Project for this record',
-          'required' => true,
+          'required' => TRUE,
           'table_name' => 'civicrm_volunteer_project_contact',
           'entity' => 'ProjectContact',
           'bao' => 'CRM_Volunteer_DAO_ProjectContact',
@@ -128,7 +128,7 @@ class CRM_Volunteer_DAO_ProjectContact extends CRM_Core_DAO {
           'type' => CRM_Utils_Type::T_INT,
           'title' => ts('Contact ID', array('domain' => 'org.civicrm.volunteer')) ,
           'description' => 'Foreign key to the Contact for this record',
-          'required' => true,
+          'required' => TRUE,
           'table_name' => 'civicrm_volunteer_project_contact',
           'entity' => 'ProjectContact',
           'bao' => 'CRM_Volunteer_DAO_ProjectContact',
@@ -139,7 +139,7 @@ class CRM_Volunteer_DAO_ProjectContact extends CRM_Core_DAO {
           'type' => CRM_Utils_Type::T_INT,
           'title' => ts('Relationship Type', array('domain' => 'org.civicrm.volunteer')) ,
           'description' => 'Nature of the contact\'s relationship to the Volunteer Project (e.g., Beneficiary). See option group volunteer_project_relationship.',
-          'required' => true,
+          'required' => TRUE,
           'table_name' => 'civicrm_volunteer_project_contact',
           'entity' => 'ProjectContact',
           'bao' => 'CRM_Volunteer_DAO_ProjectContact',
@@ -188,7 +188,7 @@ class CRM_Volunteer_DAO_ProjectContact extends CRM_Core_DAO {
    *
    * @return array
    */
-  static function &import($prefix = false) {
+  static function &import($prefix = FALSE) {
     $r = CRM_Core_DAO_AllCoreTables::getImports(__CLASS__, 'volunteer_project_contact', $prefix, array());
     return $r;
   }
@@ -199,7 +199,7 @@ class CRM_Volunteer_DAO_ProjectContact extends CRM_Core_DAO {
    *
    * @return array
    */
-  static function &export($prefix = false) {
+  static function &export($prefix = FALSE) {
     $r = CRM_Core_DAO_AllCoreTables::getExports(__CLASS__, 'volunteer_project_contact', $prefix, array());
     return $r;
   }

--- a/CRM/Volunteer/Form/IncludeProfile.php
+++ b/CRM/Volunteer/Form/IncludeProfile.php
@@ -26,7 +26,7 @@ class CRM_Volunteer_Form_IncludeProfile extends CRM_Core_Form {
    * @param string $label Label
    * @param array $configs Optional, for addProfileSelector(), defaults to using getProfileSelectorTypes()
    */
-  public static function buildProfileWidget(&$form, $count, $prefix = '', $label = 'Include Profile', $configs = null) {
+  public static function buildProfileWidget(&$form, $count, $prefix = '', $label = 'Include Profile', $configs = NULL) {
     extract( ( is_null($configs) ) ? self::getProfileSelectorTypes() : $configs );
     $element = $prefix . "custom_signup_profiles[$count]";
     $form->assign('profileItem', $count);

--- a/CRM/Volunteer/Form/Settings.php
+++ b/CRM/Volunteer/Form/Settings.php
@@ -74,7 +74,7 @@ class CRM_Volunteer_Form_Settings extends CRM_Core_Form {
         'volunteer_project_default_profiles_' . $audience['type'],
         $audience['description'],
         $profileList,
-        false, // is required,
+        FALSE, // is required,
         array(
           "placeholder" => ts("- none -", array('domain' => 'org.civicrm.volunteer')),
           "multiple" => "multiple",
@@ -94,8 +94,8 @@ class CRM_Volunteer_Form_Settings extends CRM_Core_Form {
       'volunteer_project_default_campaign',
       ts('Campaign', array('domain' => 'org.civicrm.volunteer')),
       $campaignList,
-      false, // is required,
-      array("placeholder" => true)
+      FALSE, // is required,
+      array("placeholder" => TRUE)
     );
 
     $locBlocks = civicrm_api3('VolunteerProject', 'locations', array());
@@ -104,7 +104,7 @@ class CRM_Volunteer_Form_Settings extends CRM_Core_Form {
       'volunteer_project_default_locblock',
       ts('Location', array('domain' => 'org.civicrm.volunteer')),
       $locBlocks['values'],
-      false, // is required,
+      FALSE, // is required,
       array("placeholder" => ts("- none -", array('domain' => 'org.civicrm.volunteer')))
     );
 
@@ -112,8 +112,8 @@ class CRM_Volunteer_Form_Settings extends CRM_Core_Form {
       'checkbox',
       'volunteer_project_default_is_active',
       ts('Are new Projects active by default?', array('domain' => 'org.civicrm.volunteer')),
-      null,
-      false
+      NULL,
+      FALSE
     );
 
     $this->addProjectRelationshipFields();
@@ -127,7 +127,7 @@ class CRM_Volunteer_Form_Settings extends CRM_Core_Form {
         "blacklist" => ts("Blacklist", array('domain' => 'org.civicrm.volunteer')),
         "whitelist" => ts("Whitelist", array('domain' => 'org.civicrm.volunteer')),
       ),
-      true
+      TRUE
     );
 
     $results = civicrm_api3('OptionValue', 'get', array(
@@ -145,7 +145,7 @@ class CRM_Volunteer_Form_Settings extends CRM_Core_Form {
       'volunteer_general_campaign_filter_list',
       ts('Campaign Type(s)', array('domain' => 'org.civicrm.volunteer')),
       $campaignTypes,
-      false, // is required,
+      FALSE, // is required,
       array(
         "placeholder" => ts("- none -", array('domain' => 'org.civicrm.volunteer')),
         "multiple" => "multiple",
@@ -193,7 +193,7 @@ class CRM_Volunteer_Form_Settings extends CRM_Core_Form {
         "volunteer_project_default_contacts_relationship_$name",
         ts('Default to Contact(s) Having this Relationship with the Acting Contact', array('domain' => 'org.civicrm.volunteer')),
         $this->getValidRelationshipTypes(),
-        false, // is required,
+        FALSE, // is required,
         array(
           'class' => 'crm-select2',
           'data-fieldgroup' => 'Default Project Settings',
@@ -356,7 +356,7 @@ class CRM_Volunteer_Form_Settings extends CRM_Core_Form {
    */
   function getSettingMetadata($settingName, $attr) {
     if (!$settingName || !$attr) {
-      return false;
+      return FALSE;
     }
     $setting = CRM_Utils_Array::value($settingName, $this->_settingsMetadata, array());
     return CRM_Utils_Array::value($attr, $setting);

--- a/CRM/Volunteer/Form/VolunteerSignUp.php
+++ b/CRM/Volunteer/Form/VolunteerSignUp.php
@@ -388,7 +388,7 @@ class CRM_Volunteer_Form_VolunteerSignUp extends CRM_Core_Form {
           while ($i < $additionalVolunteerQuantity) {
             $additionalVolunteerProfiles[$i] = array();
             $additionalVolunteerProfiles[$i]['prefix'] = "additionalVolunteers_$i";
-            $additionalVolunteerProfiles[$i]['profiles'] = $this->buildAdditionalVolunteerTemplate($additionalVolunteerProfiles[$i]['prefix'], false);
+            $additionalVolunteerProfiles[$i]['profiles'] = $this->buildAdditionalVolunteerTemplate($additionalVolunteerProfiles[$i]['prefix'], FALSE);
             $i++;
           }
           $this->assign('additionalVolunteerProfiles', $additionalVolunteerProfiles);
@@ -572,7 +572,7 @@ class CRM_Volunteer_Form_VolunteerSignUp extends CRM_Core_Form {
    * @return int
    *   The contact id of the user for whom this data was saved (This can be a new contact)
    */
-  private function processContactProfileData(array $profileValues, array $profileFields, $cid = null) {
+  private function processContactProfileData(array $profileValues, array $profileFields, $cid = NULL) {
     // Search for duplicate
     if (!$cid) {
       $dedupeParams = CRM_Dedupe_Finder::formatParams($profileValues, 'Individual');
@@ -688,7 +688,7 @@ class CRM_Volunteer_Form_VolunteerSignUp extends CRM_Core_Form {
    *   Returns an array of field definitions that have been added to the form.
    *   This result can be passed to a Smarty template as a variable.
    */
-  function buildCustom(array $profileIds = array(), $contactID = null, $prefix = '') {
+  function buildCustom(array $profileIds = array(), $contactID = NULL, $prefix = '') {
     $profiles = array();
     $fieldList = array(); // master field list
 
@@ -708,8 +708,8 @@ class CRM_Volunteer_Form_VolunteerSignUp extends CRM_Core_Form {
           CRM_Profile_Form::MODE_CREATE,
           $contactID,
           TRUE,
-          null,
-          null,
+          NULL,
+          NULL,
           $prefix
         );
         $profiles[$profileID][$key] = $fieldList[$key] = $field;
@@ -731,7 +731,7 @@ class CRM_Volunteer_Form_VolunteerSignUp extends CRM_Core_Form {
    *   An array of the additional volunteer profiles. The array is empty if
    *   there are none.
    */
-  function buildAdditionalVolunteerTemplate($prefix = "additionalVolunteersTemplate", $assign = true) {
+  function buildAdditionalVolunteerTemplate($prefix = "additionalVolunteersTemplate", $assign = TRUE) {
     $profiles = $this->buildCustom($this->getAdditionalVolunteerProfileIDs(), 0, $prefix);
 
     if($assign) {

--- a/api/v3/VolunteerProjectContact.php
+++ b/api/v3/VolunteerProjectContact.php
@@ -96,7 +96,7 @@ function civicrm_api3_volunteer_project_contact_get($params) {
       //Following that, when you pass a null value into getsingle, it finds 3 results and errors out
       //This solution was created to fall back on relationship_type_id if present in
       //$params, and if not, skip loading the relationship type label.
-      $rType = false;
+      $rType = FALSE;
       $rType = (array_key_exists("relationship_type_id", $params) ) ? $params['relationship_type_id'] : $rType;
       $rType = (array_key_exists("relationship_type_id", $projectContact) ) ? $projectContact['relationship_type_id'] : $rType;
 

--- a/volunteer.php
+++ b/volunteer.php
@@ -169,7 +169,7 @@ function volunteer_civicrm_tabset($tabsetName, &$tabs, $context) {
         'valid' => TRUE,
         'active' => TRUE,
         'class' => 'livePage',
-        'current' => false,
+        'current' => FALSE,
       );
 
       if (!CRM_Volunteer_BAO_Project::isActive($eventId, CRM_Event_DAO_Event::$_tableName)) {


### PR DESCRIPTION
Hi, we were advised in the referenced PRs (see below) that CiviRCM uses the Drupal Coding standards and we want to help you to standardize the rest of your codebase. To that end we found some lowercase constants that are inconsistent with the CiviRCM / Drupal standards.

https://docs.civicrm.org/dev/en/latest/standards/php/
https://www.drupal.org/docs/develop/standards/coding-standards#naming

See:
https://github.com/civicrm/civicrm-wordpress/pull/149
https://github.com/civicrm/civicrm-drupal/pull/570