### PR TITLE
Ensure that Volunteer Report instance can only be accessed by people …

### DIFF
--- a/CRM/Volunteer/Form/VolunteerReport.mgd.php
+++ b/CRM/Volunteer/Form/VolunteerReport.mgd.php
@@ -32,6 +32,7 @@ return array(
       'title' => $labelVolunteerReport,
       'description' => $labelVolunteerReport,
       'report_id' => 'volunteer',
+      'permissions' => 'access CiviReport',
       'form_values' => serialize(array(
         'fields' => array(
           'contact_assignee' => '1',


### PR DESCRIPTION
…with access to CiviReport

At present if someone was to go to the public url civicrm/report/list they would potentially be able to create copies, run the report etc. This ensures that you have to at least access CiviReport to do anything with the report

ping @jkingsnorth @totten @eileenmcnaughton @ginkgomzd 