### PR TITLE
Fix notice against 5.24.0 due to core function signature change

### DIFF
--- a/CRM/Volunteer/BAO/Project.php
+++ b/CRM/Volunteer/BAO/Project.php
@@ -632,7 +632,7 @@ class CRM_Volunteer_BAO_Project extends CRM_Volunteer_DAO_Project {
    * @deprecated since version 4.7.21-2.3.0
    *   Internal core methods should not be extended by third-party code.
    */
-  public function copyValues(&$params, $serializeArrays = FALSE) {
+  public function copyValues($params) {
     if (is_a($params, 'CRM_Core_DAO')) {
       $params = get_object_vars($params);
     }
@@ -644,7 +644,7 @@ class CRM_Volunteer_BAO_Project extends CRM_Volunteer_DAO_Project {
        */
       $params['is_active'] = CRM_Volunteer_BAO_Project::isOff($params['is_active']) ? 0 : 1;
     }
-    return parent::copyValues($params, $serializeArrays);
+    return parent::copyValues($params);
   }
 
   /**

--- a/info.xml
+++ b/info.xml
@@ -8,11 +8,10 @@
     <author>Ginkgo Street Labs</author>
     <email>inquire@ginkgostreet.com</email>
   </maintainer>
-  <releaseDate>2018-06-29</releaseDate>
-  <version>4.7.31-2.3.1</version>
+  <releaseDate>2020-02-20</releaseDate>
+  <version>5.24.0-2.3.2</version>
   <compatibility>
-    <ver>4.7</ver>
-    <ver>5.0</ver>
+    <ver>5.24</ver>
   </compatibility>
   <comments>
     Developed by Ginkgo Street Labs and CiviCRM, LLC with contributions from the community. Special thanks to Friends of Georgia State Parks &amp; Historic Sites for funding the initial release, and to The Manhattan Neighborhood Network for funding the 1.4 release.


### PR DESCRIPTION
The signature for copyValues in 5.24.0 no longer has serialize as a second param. This removes
& increments the version so only sites on 5.24.0+ should get the change (This is the strategy I
use in all my extensions - ie specifying which civi version each release is tested on.)