### PR TITLE
Expose field “Address Name” in volunteer project location

### DIFF
--- a/ang/volunteer/Project.html
+++ b/ang/volunteer/Project.html
@@ -49,7 +49,7 @@
           <fieldset class="crm-vol-location-address">
             <legend>{{ts("Address")}}</legend>
             <div class="crm-vol-location-name" crm-ui-field='{name: "projectForm.locBlock.name", title: ts("Address Name")}'>
-             <input size="30" crm-ui-id="projectForm.locBlock.name"  ng-model="locBlock.address.name" />
+              <input size="30" crm-ui-id="projectForm.locBlock.name"  ng-model="locBlock.address.name" />
             </div>
             <div class="crm-vol-location-street" crm-ui-field='{name: "projectForm.locBlock.street_address", title: ts("Street Address")}'>
               <input size="30" crm-ui-id="projectForm.locBlock.street_address"  ng-model="locBlock.address.street_address" />

--- a/ang/volunteer/Project.html
+++ b/ang/volunteer/Project.html
@@ -48,6 +48,9 @@
           <div class="status" ng-show="locBlock.count_loc_used > 0">{{ts("This location is used by other events/projects. Modifying location information will change values for all events/projects")}}</div>
           <fieldset class="crm-vol-location-address">
             <legend>{{ts("Address")}}</legend>
+            <div class="crm-vol-location-name" crm-ui-field='{name: "projectForm.locBlock.name", title: ts("Address Name")}'>
+             <input size="30" crm-ui-id="projectForm.locBlock.name"  ng-model="locBlock.address.name" />
+            </div>
             <div class="crm-vol-location-street" crm-ui-field='{name: "projectForm.locBlock.street_address", title: ts("Street Address")}'>
               <input size="30" crm-ui-id="projectForm.locBlock.street_address"  ng-model="locBlock.address.street_address" />
             </div>


### PR DESCRIPTION
Expose field “Address Name” in volunteer project location. This is in keeping with other location displays like contacts, events, etc.

![volunteer_addr](https://user-images.githubusercontent.com/3455173/113124694-50061600-9205-11eb-9c50-51619cee308e.png)
