### PR TITLE
Update CiviVolunteer to use angularjs.loader service rather than the …

### DIFF
--- a/CRM/Volunteer/Angular.php
+++ b/CRM/Volunteer/Angular.php
@@ -24,15 +24,14 @@ class CRM_Volunteer_Angular {
 
     CRM_Core_Resources::singleton()->addScriptFile('civicrm.packages', 'jquery/plugins/jquery.notify.min.js', 10, 'html-header');
 
-    $loader = new \Civi\Angular\AngularLoader();
-    $loader->setModules(array('volunteer'));
+    $loader = Civi::service('angularjs.loader');
+    $loader->addModules(['volunteer']);
     $loader->setPageName('civicrm/vol');
-    $loader->load();
-    \Civi::resources()->addSetting(array(
-      'crmApp' => array(
+    \Civi::resources()->addSetting([
+      'crmApp' => [
         'defaultRoute' => $defaultRoute,
-      ),
-    ));
+      ],
+    ]);
 
     self::$loaded = TRUE;
   }

--- a/templates/CRM/Volunteer/Page/Angular.tpl
+++ b/templates/CRM/Volunteer/Page/Angular.tpl
@@ -1,5 +1,5 @@
 {literal}
-    <div ng-app="crmApp" id="crm_volunteer_angular_frame">
-        <div ng-view></div>
-    </div>
+  <crm-angular-js modules="crmApp" id="crm_volunteer_angular_frame">
+    <div ng-view></div>
+  </crm-angular-js>
 {/literal}


### PR DESCRIPTION
…AngularLoader directly

This makes chances necessary to remove a deprecation notice triggered by the changes here https://github.com/civicrm/civicrm-core/pull/20419

ping @MikeyMJCO @ginkgomzd @colemanw 