### PR TITLE
Cleanup campaign selectors to use EntityRef

### DIFF
--- a/CRM/Volunteer/Form/Settings.php
+++ b/CRM/Volunteer/Form/Settings.php
@@ -84,18 +84,10 @@ class CRM_Volunteer_Form_Settings extends CRM_Core_Form {
       );
     }
 
-    $campaigns = civicrm_api3('VolunteerUtil', 'getcampaigns', array());
-    $campaignList = array();
-    foreach ($campaigns['values'] as $campaign) {
-      $campaignList[$campaign['id']] = $campaign['title'];
-    }
-    $this->add(
-      'select',
+    $this->addEntityRef(
       'volunteer_project_default_campaign',
       ts('Campaign', array('domain' => 'org.civicrm.volunteer')),
-      $campaignList,
-      false, // is required,
-      array("placeholder" => true)
+      ['entity' => 'Campaign', 'select' => ['minimumInputLength' => 0, 'allowClear' => TRUE]]
     );
 
     $locBlocks = civicrm_api3('VolunteerProject', 'locations', array());

--- a/CRM/Volunteer/Page/Angular.php
+++ b/CRM/Volunteer/Page/Angular.php
@@ -10,4 +10,24 @@ class CRM_Volunteer_Page_Angular extends \CRM_Core_Page {
     parent::run();
   }
 
+  /**
+   * Settings factory function for the volunteer Angular module
+   * @return array
+   */
+  public static function loadSettings() {
+    $settings = [];
+    $prefs = civicrm_api4('Setting', 'get', [
+      'checkPermissions' => FALSE,
+      'select' => [
+        'volunteer_general_campaign_filter_type',
+        'volunteer_general_campaign_filter_list',
+      ],
+    ], ['name' => 'value']);
+    $campaignFilterOperator = $prefs['volunteer_general_campaign_filter_type'] === 'whitelist' ? 'IN' : 'NOT IN';
+    $settings['campaignFilter'] = $prefs['volunteer_general_campaign_filter_list'] ?
+      ['campaign_type_id' => [$campaignFilterOperator => $prefs['volunteer_general_campaign_filter_list']]] : [];
+
+    return $settings;
+  }
+
 }

--- a/ang/volunteer/Project.js
+++ b/ang/volunteer/Project.js
@@ -37,11 +37,6 @@
               controller: 'VolunteerProject'
             });
           },
-          campaigns: function(crmApi) {
-            return crmApi('VolunteerUtil', 'getcampaigns').then(function(data) {
-              return data.values;
-            });
-          },
           relationship_data: function(crmApi, $route) {
             var params = {
               "sequential": 1,

--- a/ang/volunteer/Projects.html
+++ b/ang/volunteer/Projects.html
@@ -1,9 +1,4 @@
 <div class="crm-container">
-  <!-- TODO for VOL-267: Remove beneficiaries debugging block. -->
-  <div crm-ui-debug="beneficiaries"></div>
-  <div crm-ui-debug="campaigns"></div>
-  <div crm-ui-debug="projects"></div>
-  <div crm-ui-debug="searchParams"></div>
 
   <div class="help" ng-show="!canAccessAllProjects">
     <p>
@@ -41,11 +36,9 @@
               </select>
             </div>
             <div class="crm-vol-field crm-vol-field-projects-search-campaign" crm-ui-field="{name: 'volProjectSearchForm.campaign_id', title: ts('Campaign')}">
-              <select class="big crm-form-select crm-vol-campaign" crm-ui-select="{placeholder: ts('Filter by Campaign'), allowClear:true}"
+              <input class="big crm-form-entityref crm-vol-campaign" crm-entityref="{entity: 'Campaign', api: {params: campaignFilter}, select: {minimumInputLength: 0, placeholder: ts('Filter by Campaign'), allowClear:true}}"
                       ng-change="clearCampaign()"
-                      ng-options="key as value.title for (key , value) in campaigns  track by key" ng-model="searchParams.campaign_id">
-                <option />
-              </select>
+                      ng-model="searchParams.campaign_id">
             </div>
             <div class="crm-vol-field crm-vol-field-projects-search-active" crm-ui-field="{name: 'volProjectSearchForm.is_active', title: ts('Active')}">
               <label>

--- a/ang/volunteer/Projects.js
+++ b/ang/volunteer/Projects.js
@@ -45,11 +45,6 @@
               });
             });
           },
-          campaigns: function(crmApi) {
-            return crmApi('VolunteerUtil', 'getcampaigns').then(function(data) {
-              return data.values;
-            });
-          },
           volunteerBackbone: function(volBackbone) {
             return volBackbone.load();
           }
@@ -59,7 +54,7 @@
   );
 
   // TODO for VOL-276: Remove reference to beneficiaries object, based on deprecated API.
-  angular.module('volunteer').controller('VolunteerProjects', function ($scope, $filter, crmApi, crmStatus, crmUiHelp, projectData, $location, volunteerBackbone, beneficiaries, campaigns, $window) {
+  angular.module('volunteer').controller('VolunteerProjects', function ($scope, $filter, crmApi, crmStatus, crmUiHelp, projectData, $location, volunteerBackbone, beneficiaries, $window) {
     // The ts() and hs() functions help load strings for this module.
     var ts = $scope.ts = CRM.ts('org.civicrm.volunteer');
     var hs = $scope.hs = crmUiHelp({file: 'CRM/volunteer/Projects'}); // See: templates/CRM/volunteer/Projects.hlp
@@ -72,7 +67,7 @@
     $scope.allSelected = false;
     // TODO for VOL-276: Remove reference to beneficiaries object, based on deprecated API.
     $scope.beneficiaries = beneficiaries;
-    $scope.campaigns = campaigns;
+    $scope.campaignFilter = CRM.volunteer.campaignFilter;
     $scope.needBase = CRM.url("civicrm/volunteer/need");
     $scope.assignBase = CRM.url("civicrm/volunteer/assign");
     $scope.urlPublicVolOppSearch = CRM.url('civicrm/vol/', '', 'front') + '#/volunteer/opportunities';

--- a/api/v3/VolunteerUtil.php
+++ b/api/v3/VolunteerUtil.php
@@ -222,53 +222,6 @@ function civicrm_api3_volunteer_util_getbeneficiaries($params) {
 }
 
 /**
- * This method returns a list of active campaigns
- *
- * @param array $params
- *   Not presently used.
- * @return array
- */
-function civicrm_api3_volunteer_util_getcampaigns($params) {
-  $filterType = civicrm_api3('Setting', 'getvalue', array(
-    'name' => 'volunteer_general_campaign_filter_type',
-  ));
-  $filterList = civicrm_api3('Setting', 'getvalue', array(
-    'name' => 'volunteer_general_campaign_filter_list',
-  ));
-
-  $campaignParams = array(
-    "options" => array("limit" => 0),
-    "return" => "title,id",
-    "is_active" => 1
-  );
-
-  //Filter the campaigns by Campaign type if the settings
-  //are set to do so.
-  switch($filterType) {
-    case "whitelist":
-      if (empty($filterList)) {
-        $result = array();
-      } else {
-        $campaignParams['campaign_type_id'] = array('IN' => $filterList);
-      }
-      break;
-    case "blacklist":
-    default:
-      if (!empty($filterList)) {
-        $campaignParams['campaign_type_id'] = array('NOT IN' => $filterList);
-      }
-      break;
-  }
-
-  if (!isset($result)) {
-    $api = civicrm_api3('Campaign', 'get', $campaignParams);
-    $result = $api['values'];
-  }
-
-  return civicrm_api3_create_success($result, "VolunteerUtil", "getcampaigns", $params);
-}
-
-/**
  * This function returns the enabled countries in CiviCRM.
  *
  * @param array $params

--- a/volunteer.php
+++ b/volunteer.php
@@ -574,7 +574,7 @@ function volunteer_civicrm_angularModules(&$angularModules) {
       ),
     'css' => array (0 => 'ang/volunteer.css'),
     'partials' => array (0 => 'ang/volunteer'),
-    'settings' => array(),
+    'settingsFactory' => ['CRM_Volunteer_Page_Angular', 'loadSettings'],
   );
 
   // Perhaps the placement of this code is a little hackish; unless/until we


### PR DESCRIPTION
This improves performance and reduces code complexity by loading campaigns via entityRef instead of pre-loading them with a custom-built api action.
![image](https://user-images.githubusercontent.com/2874912/120944948-1968e200-c705-11eb-853b-047d6bc5c266.png)
