### PR TITLE
Fix ts() in angular templates to use one-time binding

### DIFF
--- a/ang/volunteer/Project.html
+++ b/ang/volunteer/Project.html
@@ -14,7 +14,7 @@
   <form class="crm-form-block" name="projectForm" crm-ui-id-scope>
 
     <fieldset class="crm-vol-project-settings" crm-ui-id-scope>
-      <legend>{{ts("Project Settings")}}</legend>
+      <legend>{{:: ts("Project Settings") }}</legend>
       <div class="crm-vol-title" crm-ui-field="{name: 'projectForm.title', title: ts('Project Title')}">
         <input class="big crm-form-text" crm-ui-id="projectForm.title" ng-model="project.title" ng-required="true" />
       </div>
@@ -23,7 +23,7 @@
         <p>
           <span class="crm-button crm-icon-button crm-vol-button crm-vol-preview-description crm-vol-project-preview-description" ng-click="previewDescription()">
             <span class="crm-button-icon ui-icon-comment"> </span>
-            <span class="crm-button-text">{{ts('Preview Description')}}</span>
+            <span class="crm-button-text">{{:: ts('Preview Description') }}</span>
           </span>
         </p>
         <div id=crm-vol-form-textarea-wrapper>
@@ -45,9 +45,9 @@
           <option />
         </select>
         <div id="crm-vol-location-block" class="crm-vol-extra-top" crm-ui-accordion="{title: ts('Edit Location'), collapsed: project.loc_block_id !==0}" ng-hide="!project.loc_block_id">
-          <div class="status" ng-show="locBlock.count_loc_used > 0">{{ts("This location is used by other events/projects. Modifying location information will change values for all events/projects")}}</div>
+          <div class="status" ng-show="locBlock.count_loc_used > 0">{{:: ts("This location is used by other events/projects. Modifying location information will change values for all events/projects") }}</div>
           <fieldset class="crm-vol-location-address">
-            <legend>{{ts("Address")}}</legend>
+            <legend>{{:: ts("Address") }}</legend>
             <div class="crm-vol-location-name" crm-ui-field='{name: "projectForm.locBlock.name", title: ts("Address Name")}'>
               <input size="30" crm-ui-id="projectForm.locBlock.name"  ng-model="locBlock.address.name" />
             </div>
@@ -80,10 +80,10 @@
             </div>
           </fieldset>
           <fieldset class="crm-vol-location-phone">
-            <legend>{{ts("Phone")}}</legend>
+            <legend>{{:: ts("Phone") }}</legend>
             <div class="crm-vol-location-phone1" crm-ui-field='{name: "projectForm.locBlock.phone1", title: ts("Phone 1")}'>
               <input crm-ui-id="projectForm.locBlock.phone1"  ng-model="locBlock.phone.phone" />
-              {{ts("ext.")}} <input size="5"  ng-model="locBlock.phone.phone_ext" />
+              {{:: ts("ext.") }} <input size="5"  ng-model="locBlock.phone.phone_ext" />
               <select crm-ui-select="{width: '100', allowClear: true}" ng-model="locBlock.phone.phone_type_id">
                 <option />
                 <option ng-repeat="(pTypeId, pType) in phone_types" value="{{pTypeId}}">{{pType}}</option>
@@ -91,7 +91,7 @@
             </div>
             <div class="crm-vol-location-phone2" crm-ui-field='{name: "projectForm.locBlock.phone2", title: ts("Phone 2")}'>
               <input crm-ui-id="projectForm.locBlock.phone2" ng-model="locBlock.phone_2.phone" />
-              {{ts("ext.")}} <input size="5" ng-model="locBlock.phone_2.phone_ext" />
+              {{:: ts("ext.") }} <input size="5" ng-model="locBlock.phone_2.phone_ext" />
               <select crm-ui-select="{width: '100', allowClear: true}" ng-model="locBlock.phone_2.phone_type_id">
                 <option />
                 <option ng-repeat="(pTypeId, pType) in phone_types" value="{{pTypeId}}">{{pType}}</option>
@@ -99,7 +99,7 @@
             </div>
           </fieldset>
           <fieldset class="crm-vol-location-email">
-            <legend>{{ts("Email")}}</legend>
+            <legend>{{:: ts("Email") }}</legend>
             <div class="crm-vol-location-email1" crm-ui-field='{name: "projectForm.locBlock.email1", title: ts("Email 1")}'>
               <input size="30" type="email" crm-ui-id="projectForm.locBlock.email1" ng-model="locBlock.email.email" />
             </div>
@@ -117,7 +117,7 @@
     </fieldset>
 
     <fieldset class="crm-vol-relationships" ng-if="showRelationshipBlock" crm-ui-id-scope>
-      <legend>{{ts("Relationships")}}</legend>
+      <legend>{{:: ts("Relationships") }}</legend>
       <div ng-repeat="relType in relationship_types">
         <div crm-ui-field="{name: projectForm[relType.name], title: ts(relType.label)}" ng-class="'crm-vol-rel-' + relType.name">
           <input crm-ui-id="projectForm[relType.name]" crm-entityref="{entity: 'Contact', select: {allowClear:true, multiple: true}}" ng-model="relationships[relType.value]" />
@@ -127,13 +127,13 @@
     </fieldset>
 
     <fieldset class="crm-vol-profiles" ng-if="showProfileBlock">
-      <legend>{{ts("Volunteer Registration")}}</legend>
+      <legend>{{:: ts("Volunteer Registration") }}</legend>
       <div class="help">
         <p>
-          {{ts("What questions would you like to ask your volunteers? Select one or more Profiles below to tailor the registration forms for this project.")}}
+          {{:: ts("What questions would you like to ask your volunteers? Select one or more Profiles below to tailor the registration forms for this project.") }}
         </p>
         <p>
-          {{ts('You may create up to two sign up forms for a volunteer project: one for individual registrations and another for group registrations. The "Use For" field specifies whether the Profile should be used for individual registrations, group registrations, or both. For group registrations, it is recommended that a single, short Profile be used.')}}
+          {{:: ts('You may create up to two sign up forms for a volunteer project: one for individual registrations and another for group registrations. The "Use For" field specifies whether the Profile should be used for individual registrations, group registrations, or both. For group registrations, it is recommended that a single, short Profile be used.') }}
         </p>
       </div>
       <div id="org_civicrm_volunteer-sign-up-profiles">
@@ -144,7 +144,7 @@
 
           <div class="crm-profile-selector-wrapper crm-section">
             <div class="label">
-              <label>{{ts("Profile:")}}</label>
+              <label>{{:: ts("Profile:") }}</label>
             </div>
             <div class="content">
               <input ng-if="supporting_data.use_profile_editor" crm-profile-selector="{}"
@@ -160,7 +160,7 @@
 
           <div class="crm-volunteer-profile-use-type crm-section">
             <div class="label">
-              <label>{{ts("Use For:")}}</label>
+              <label>{{:: ts("Use For:") }}</label>
             </div>
             <div class="content">
               <select ng-model="profile.module_data.audience" crm-ui-select="{width: 'style'}" ng-change="validateProfileSelections()">
@@ -184,11 +184,11 @@
       </span>
       <span ng-show="formContext === 'standAlone'" class="crm-button crm-icon-button crm-vol-button crm-vol-save-done crm-vol-project-save-done" ng-click="saveAndDone()">
         <span class="crm-button-icon ui-icon-circle-check"> </span>
-        <span class="crm-button-text">{{ts('Save and Done')}}</span>
+        <span class="crm-button-text">{{:: ts('Save and Done') }}</span>
       </span>
       <span class="crm-button crm-icon-button crm-button-type-cancel crm-vol-button crm-vol-cancel crm-vol-project-cancel" ng-click="cancel()">
         <span class="crm-button-icon ui-icon-close"> </span>
-        <span class="crm-button-text">{{ts('Cancel')}}</span>
+        <span class="crm-button-text">{{:: ts('Cancel') }}</span>
       </span>
     </div>
 

--- a/ang/volunteer/Projects.html
+++ b/ang/volunteer/Projects.html
@@ -7,7 +7,7 @@
 
   <div class="help" ng-show="!canAccessAllProjects">
     <p>
-      {{ts("This page displays only the volunteer projects which you have access to edit.")}}
+      {{:: ts("This page displays only the volunteer projects which you have access to edit.") }}
       <!-- not translated because HTML tags in a ts() choke Angular -->
       For a list of all volunteer opportunities on the site, visit the <a href="{{urlPublicVolOppSearch}}">public search form</a>.
     </p>
@@ -17,13 +17,15 @@
     <div class="clear"></div>
     <div class="crm-vol-buttons crm-vol-mange-buttons crm-vol-half-responsive">
 
-      <a href="#/volunteer/manage/0" class="button"><span><div class="icon ui-icon-plus"></div>{{ts('Add Project')}}</span></a><br /><br />
+      <a href="#/volunteer/manage/0" class="button"><span><div class="icon ui-icon-plus"></div>{{:: ts('Add Project') }}</span></a><br /><br />
 
       <select crm-ui-select="{placeholder: ts('Bulk Actions'), allowClear: true, width: '150'}" ng-model="batchAction" id="batchAction">
         <option />
         <option ng-repeat="(key, action) in batchActions" value="{{key}}">{{action.label}}</option>
       </select>
-      <input type="button" value="{{ts('Run')}}" ng-click="runBatch()" />
+      <button type="button" ng-click="runBatch()" >
+        {{:: ts('Run') }}
+      </button>
     </div>
     <div class="crm-vol-search crm-vol-manage-search crm-vol-half-responsive">
       <form name="volProjectSearchForm" crm-ui-id-scope>
@@ -66,11 +68,11 @@
       <thead>
         <tr role="row">
           <th class="ui-state-default crm-vol-manage-toggle"><input type="checkbox" ng-model="allSelected" ng-change="selectAll()" /></th>
-          <th class="ui-state-default crm-vol-manage-project">{{ ts('Volunteer Project') }}</th>
-          <th class="ui-state-default crm-vol-manage-entity">{{ ts('Associated Entity') }}</th>
-          <th class="ui-state-default crm-vol-manage-beneficiaries">{{ ts('Beneficiaries') }}</th>
-          <th class="ui-state-default crm-vol-manage-location">{{ ts('Location') }}</th>
-          <th class="ui-state-default crm-vol-manage-active">{{ ts('Active') }}</th>
+          <th class="ui-state-default crm-vol-manage-project">{{:: ts('Volunteer Project') }}</th>
+          <th class="ui-state-default crm-vol-manage-entity">{{:: ts('Associated Entity') }}</th>
+          <th class="ui-state-default crm-vol-manage-beneficiaries">{{:: ts('Beneficiaries') }}</th>
+          <th class="ui-state-default crm-vol-manage-location">{{:: ts('Location') }}</th>
+          <th class="ui-state-default crm-vol-manage-active">{{:: ts('Active') }}</th>
           <th class="ui-state-default crm-vol-manage-actionlinks"></th>
         </tr>
       </thead>
@@ -89,12 +91,12 @@
         <td class="crm-vol-manage-location" ng-bind-html="formatLocation(project)"></td>
         <td class="crm-vol-manage-active">{{ project.is_active == 1 ? ts("Yes") : ts("No") }}</td>
         <td class="crm-vol-manage-actionlinks right nowrap">
-          <div><a href="#/volunteer/manage/{{project.id}}">{{ ts('Edit') }}</a></div>
-          <div><a ng-click="backbonePopup(ts('Define Volunteer Opportunities'), 'Define', project.id)">{{ ts('Define Volunteer Opportunities') }}</a></div>
-          <div><a ng-click="backbonePopup(ts('Assign Volunteers'), 'Assign', project.id)">{{ ts('Assign Volunteers') }}</a></div>
-          <div><a ng-click="showRoster()">{{ ts('View Volunteer Roster') }}</a></div>
-          <div><a ng-click="showLogHours()">{{ ts('Log Hours') }}</a></div>
-          <div><a target="_blank" href="#/volunteer/opportunities?project={{project.id}}&amp;hideSearch=1">{{ ts('Public Signup') }}</a></div>
+          <div><a href="#/volunteer/manage/{{project.id}}">{{:: ts('Edit') }}</a></div>
+          <div><a ng-click="backbonePopup(ts('Define Volunteer Opportunities'), 'Define', project.id)">{{:: ts('Define Volunteer Opportunities') }}</a></div>
+          <div><a ng-click="backbonePopup(ts('Assign Volunteers'), 'Assign', project.id)">{{:: ts('Assign Volunteers') }}</a></div>
+          <div><a ng-click="showRoster()">{{:: ts('View Volunteer Roster') }}</a></div>
+          <div><a ng-click="showLogHours()">{{:: ts('Log Hours') }}</a></div>
+          <div><a target="_blank" href="#/volunteer/opportunities?project={{project.id}}&amp;hideSearch=1">{{:: ts('Public Signup') }}</a></div>
         </td>
       </tr>
       </tbody>

--- a/ang/volunteer/VolOppsCtrl.html
+++ b/ang/volunteer/VolOppsCtrl.html
@@ -18,11 +18,11 @@ Required vars: volOppData(), searchParams
   <!-- Search Form -->
   <div class="crm-vol-half-responsive crm-vol-opp-show-hidden-search" ng-show="allowShowSearch">
     <div class="crm-buttons">
-      <button crm-icon="search" ng-click="showSearch()">{{ts('Filter this List of Volunteer Opportunities')}}</button>
+      <button crm-icon="search" ng-click="showSearch()">{{:: ts('Filter this List of Volunteer Opportunities') }}</button>
     </div>
   </div>
   <div class="crm-vol-half-responsive crm-vol-opp-search" ng-hide="hideSearch">
-    <h2>{{ts('Find Volunteer Opportunities')}}</h2>
+    <h2>{{:: ts('Find Volunteer Opportunities') }}</h2>
     <form name="volOppSearchForm" crm-ui-id-scope>
       <div class="crm-block ui-tabs ui-widget ui-widget-content ui-corner-all">
         <div class="crm-group" crm-ui-id-scope>
@@ -119,7 +119,7 @@ Required vars: volOppData(), searchParams
           </div>
         </div>
         <div class="crm-buttons">
-          <button crm-icon="search" ng-click="search()">{{ts('Search')}}</button>
+          <button crm-icon="search" ng-click="search()">{{:: ts('Search') }}</button>
         </div>
       </div>
     </form>
@@ -128,25 +128,25 @@ Required vars: volOppData(), searchParams
 
   <!-- Shopping Cart -->
   <div class="crm-vol-half-responsive crm-vol-opp-cart" ng-class="{'floating_cart': cartIsFloating, 'contents_visible': showCartContents}">
-    <h2>{{ts('Your Selected Volunteer Opportunities')}}</h2>
+    <h2>{{:: ts('Your Selected Volunteer Opportunities') }}</h2>
     <div class="crm-block ui-tabs ui-widget ui-widget-content ui-corner-all " ng-form="volOppCheckoutForm" crm-ui-id-scope>
       <div class="crm-vol-opp-cart-message-wrapper">
         <div class="crm-vol-opp-cart-large-indicator">
-          <span>{{itemCountInCart}} {{ts('Commitments')}}</span>
+          <span>{{itemCountInCart}} {{:: ts('Commitments') }}</span>
         </div>
         <div class="crm-vol-opp-cart-message">
-          <span ng-show="itemCountInCart === 0">{{ts('Make a commitment by clicking the checkbox for the volunteer opportunity that interests you.')}}</span>
-          <span ng-hide="itemCountInCart === 0">{{ts('Great! Make as many selections you like, then click \'Sign Up!\' to complete your registration.')}}</span>
+          <span ng-show="itemCountInCart === 0">{{:: ts('Make a commitment by clicking the checkbox for the volunteer opportunity that interests you.') }}</span>
+          <span ng-hide="itemCountInCart === 0">{{:: ts('Great! Make as many selections you like, then click \'Sign Up!\' to complete your registration.') }}</span>
         </div>
       </div>
 
       <table ng-show="showCartContents" class="display dataTable no-footer crm-vol-opp-cart-list" ng-class="{'contents_visible': showCartContents}" role="grid">
         <thead>
         <tr role="row">
-          <th class="ui-state-default crm-vol-opp-project">{{ts('Project')}}</th>
-          <th class="ui-state-default crm-vol-opp-role">{{ts('Role')}}</th>
-          <th class="ui-state-default crm-vol-opp-time">{{ts('Time')}}</th>
-          <th class="ui-state-default crm-vol-opp-toggle">{{ts('Remove')}}</th>
+          <th class="ui-state-default crm-vol-opp-project">{{:: ts('Project') }}</th>
+          <th class="ui-state-default crm-vol-opp-role">{{:: ts('Role') }}</th>
+          <th class="ui-state-default crm-vol-opp-time">{{:: ts('Time') }}</th>
+          <th class="ui-state-default crm-vol-opp-toggle">{{:: ts('Remove') }}</th>
         </tr>
         </thead>
         <tbody>
@@ -180,7 +180,7 @@ Required vars: volOppData(), searchParams
 
       <div class="crm-buttons">
         <button class="crm-vol-button crm-vol-opp-cart-sign-up" crm-icon="check" ng-click="checkout()" ng-disabled="itemCountInCart === 0">
-          {{ts('Sign Up!')}}
+          {{:: ts('Sign Up!') }}
         </button>
         <a class="crm-vol-opp-cart-show-contents" ng-hide="itemCountInCart === 0" ng-click="toggleCartList()">{{showCartContents ? ts('Hide selections') : ts('View selections')}}</a>
       </div>
@@ -192,22 +192,22 @@ Required vars: volOppData(), searchParams
   <!-- Results -->
   <div class="crm-vol-opp-results messages status no-popup" ng-show="_.size(volOppData()) === 0">
     <div class="icon inform-icon"></div>
-    {{ts('No results found. Please try different search criteria.')}}
+    {{:: ts('No results found. Please try different search criteria.') }}
   </div>
   <div class="crm-vol-opp-results" ng-show="_.size(volOppData()) > 0">
-    <h2>{{ts('Available Volunteer Opportunities')}}</h2>
+    <h2>{{:: ts('Available Volunteer Opportunities') }}</h2>
     <p class="description">
-      {{ts('For additional project or role detail, click the corresponding detail icon in the table below.')}}
+      {{:: ts('For additional project or role detail, click the corresponding detail icon in the table below.') }}
       <span class="icon ui-icon-comment"></span>
     </p>
     <table class="display dataTable no-footer" role="grid">
       <thead>
       <tr role="row">
-        <th class="ui-state-default crm-vol-opp-project">{{ts('Project')}}</th>
-        <th class="ui-state-default crm-vol-opp-beneficiary">{{ts('With')}}</th>
-        <th class="ui-state-default crm-vol-opp-role">{{ts('Role')}}</th>
-        <th class="ui-state-default crm-vol-opp-time">{{ts('Time')}}</th>
-        <th class="ui-state-default crm-vol-opp-toggle">{{ts('Sign up!')}}</th>
+        <th class="ui-state-default crm-vol-opp-project">{{:: ts('Project') }}</th>
+        <th class="ui-state-default crm-vol-opp-beneficiary">{{:: ts('With') }}</th>
+        <th class="ui-state-default crm-vol-opp-role">{{:: ts('Role') }}</th>
+        <th class="ui-state-default crm-vol-opp-time">{{:: ts('Time') }}</th>
+        <th class="ui-state-default crm-vol-opp-toggle">{{:: ts('Sign up!') }}</th>
       </tr>
       </thead>
       <tbody>


### PR DESCRIPTION
Using one-time bindings gives Angular a performance boost because it doesn't have to call `ts()` again every digest cycle.