### PR TITLE
Remove unused clientside variable

### DIFF
--- a/volunteer.php
+++ b/volunteer.php
@@ -580,15 +580,7 @@ function volunteer_civicrm_angularModules(&$angularModules) {
   // Perhaps the placement of this code is a little hackish; unless/until we
   // extend Civi\Angular\Page\Main, there doesn't appear to be a better
   // alternative. This populates CRM.permissions on the client side.
-  CRM_Core_Resources::singleton()->addPermissions(array_keys(CRM_Volunteer_Permission::getVolunteerPermissions()))
-
-    // Perhaps the placement of this code is a little hackish; unless/until we
-    // extend Civi\Angular\Page\Main, there doesn't appear to be a better
-    // alternative. This provides access to the current contact id on the
-    // client side.
-    ->addVars('org.civicrm.volunteer', array(
-      'currentContactId' => CRM_Core_Session::singleton()->getLoggedInContactID()
-    ));
+  CRM_Core_Resources::singleton()->addPermissions(array_keys(CRM_Volunteer_Permission::getVolunteerPermissions()));
 }
 
 /**


### PR DESCRIPTION
This variable `currentContactId` is pushed to the client side but never accessed.
FYI if it were needed, core already makes it available as `CRM.config.cid`.