### PR TITLE
expose Address Name in the location column of Volunteer Project

### DIFF
--- a/ang/volunteer/Projects.js
+++ b/ang/volunteer/Projects.js
@@ -107,7 +107,11 @@
       if (_.isEmpty(address)) {
         return result;
       }
-
+ 
+      if (address.name) {
+        result += address.name + '<br />';
+      }
+  
       if (address.street_address) {
         result += address.street_address;
       }


### PR DESCRIPTION
Now that we have added the field _Address Name_ in the location of the _Volunteer Project,_ we need to display the field in the Manage Projects page.

Before
---------
![bedore](https://user-images.githubusercontent.com/3455173/138675947-1755abb4-d15c-466d-a7eb-b04198e8185a.png)



After
---------
![afterr](https://user-images.githubusercontent.com/3455173/138675975-5d3fd5f5-b10e-475f-a4a9-e5afb571bbd0.png)
