### PR TITLE
add project type to civivolunteer

### DIFF
--- a/CRM/Volunteer/BAO/NeedSearch.php
+++ b/CRM/Volunteer/BAO/NeedSearch.php
@@ -187,6 +187,11 @@ class CRM_Volunteer_BAO_NeedSearch {
       $this->searchParams['project']['proximity'] = $proximity;
     }
 
+    $type = CRM_Utils_Array::value('type_id', $userSearchParams);
+    if ($type) {
+      $this->searchParams['project']['type_id'] = is_array($type) ? $type : explode(',', $type);
+    }
+
     $beneficiary = CRM_Utils_Array::value('beneficiary', $userSearchParams);
     if ($beneficiary) {
       if (!array_key_exists('project_contacts', $this->searchParams['project'])) {

--- a/CRM/Volunteer/BAO/Project.php
+++ b/CRM/Volunteer/BAO/Project.php
@@ -470,7 +470,13 @@ class CRM_Volunteer_BAO_Project extends CRM_Volunteer_DAO_Project {
     foreach ($project->fields() as $field) {
       $fieldName = $field['name'];
       if (!empty($project->$fieldName)) {
-        $query->where('!column = @value', array(
+        if (!is_array($project->$fieldName)) {
+          $exprs = '!column = @value';
+        } else {
+          $exprs = '!column IN (@value)';
+        }
+
+        $query->where($exprs, array(
           'column' => $fieldName,
           'value' => $project->$fieldName,
         ));

--- a/CRM/Volunteer/DAO/Project.php
+++ b/CRM/Volunteer/DAO/Project.php
@@ -86,7 +86,12 @@ class CRM_Volunteer_DAO_Project extends CRM_Core_DAO {
    * @var int
    */
   public $campaign_id;
-
+   /**
+   * The type associated with this Volunteer Project. Implicit FK to option_value row in volunteer_project_type option_group.
+   *
+   * @var int unsigned
+   */
+  public $type_id;
   /**
    * Class constructor.
    */
@@ -254,6 +259,20 @@ class CRM_Volunteer_DAO_Project extends CRM_Core_DAO {
             'prefetch' => 'FALSE',
           ],
           'add' => '4.5',
+        ],
+	'type_id' => [
+          'name' => 'type_id',
+          'type' => CRM_Utils_Type::T_INT,
+          'title' => ts('Type', array('domain' => 'org.civicrm.volunteer')) ,
+          'description' => 'Implicit FK to option_value row in volunteer_project_type option_group.',
+          'default' => 'NULL',
+          'table_name' => 'civicrm_volunteer_project',
+          'entity' => 'Project',
+          'bao' => 'CRM_Volunteer_DAO_Project',
+          'pseudoconstant' => array(
+            'optionGroupName' => 'volunteer_project_type',
+            'optionEditPath' => 'civicrm/admin/options/volunteer_project_type',
+          )
         ],
       ];
       CRM_Core_DAO_AllCoreTables::invoke(__CLASS__, 'fields_callback', Civi::$statics[__CLASS__]['fields']);

--- a/ang/volunteer/Project.html
+++ b/ang/volunteer/Project.html
@@ -11,6 +11,13 @@
         <input class="big crm-form-text" crm-ui-id="projectForm.title" ng-model="project.title" ng-required="true" />
       </div>
 
+      <div class="crm-vol-project-type" crm-ui-field='{name: "projectForm.type_id", title: ts("Project Type")}'>
+        <select class="big crm-form-select crm-vol-type" crm-ui-select="{placeholder: '', allowClear:true}"
+                ng-options="key as value for (key , value) in project_types track by key" ng-model="project.type_id">
+          <option />
+        </select>
+      </div>
+
       <div class="crm-vol-description" crm-ui-field="{name: 'projectForm.description', title: ts('Project Description')}">
         <p>
           <span class="crm-button crm-icon-button crm-vol-button crm-vol-preview-description crm-vol-project-preview-description" ng-click="previewDescription()">

--- a/ang/volunteer/Project.js
+++ b/ang/volunteer/Project.js
@@ -37,6 +37,11 @@
               controller: 'VolunteerProject'
             });
           },
+	  project_types: function(crmApi) {
+            return crmApi('VolunteerUtil', 'getprojecttypeoptions', {}).then(function(result) {
+              return result.values;
+            });
+          },
           relationship_data: function(crmApi, $route) {
             var params = {
               "sequential": 1,
@@ -64,8 +69,7 @@
     }
   );
 
-
-  angular.module('volunteer').controller('VolunteerProject', function($scope, $sce, $location, $q, $route, crmApi, crmUiAlert, crmUiHelp, countries, project, profile_status, relationship_data, supporting_data, location_blocks, volBackbone) {
+  angular.module('volunteer').controller('VolunteerProject', function($scope, $sce, $location, $q, $route, crmApi, crmUiAlert, crmUiHelp, countries, project, profile_status, project_types, campaigns, relationship_data, supporting_data, location_blocks, volBackbone) {
 
     /**
      * We use custom "dirty" logic rather than rely on Angular's native
@@ -167,6 +171,7 @@
     }
 
     $scope.campaignFilter = CRM.volunteer.campaignFilter;
+    $scope.project_types = project_types;
     $scope.relationship_types = supporting_data.values.relationship_types;
     $scope.phone_types = supporting_data.values.phone_types;
     $scope.supporting_data = supporting_data.values;

--- a/ang/volunteer/Projects.html
+++ b/ang/volunteer/Projects.html
@@ -30,6 +30,12 @@
             <div class="crm-vol-field crm-vol-field-projects-search-title" crm-ui-field="{name: 'volProjectSearchForm.title', title: ts('Title')}">
               <input crm-ui-id="volProjectSearchForm.title" ng-model="searchParams.title" />
             </div>
+            <div class="crm-vol-field crm-vol-field-projects-search-type" crm-ui-field="{name: 'volProjectSearchForm.type_id', title: ts('Type')}">
+              <select class="big crm-form-select crm-vol-type" crm-ui-select="{placeholder: ts('Filter by Type'), allowClear:true}"
+                      ng-options="key as value for (key , value) in project_types track by key" ng-model="searchParams.type_id">
+                <option />
+              </select>
+            </div>
             <div class="crm-vol-field crm-vol-field-projects-search-beneficiaries" crm-ui-field="{name: 'volProjectSearchForm.beneficiary', title: ts('Beneficiary')}">
               <!-- TODO for VOL-267: Replace this with an entityRef widget. -->
               <select class="big crm-form-select crm-vol-beneficiary" crm-ui-select="{placeholder: ts('Filter by Beneficiary'), allowClear:true}"

--- a/ang/volunteer/Projects.js
+++ b/ang/volunteer/Projects.js
@@ -45,6 +45,11 @@
               });
             });
           },
+          project_types: function(crmApi) {
+            return crmApi('VolunteerUtil', 'getprojecttypeoptions', {}).then(function(result) {
+              return result.values;
+            });
+          },
           volunteerBackbone: function(volBackbone) {
             return volBackbone.load();
           }
@@ -54,7 +59,7 @@
   );
 
   // TODO for VOL-276: Remove reference to beneficiaries object, based on deprecated API.
-  angular.module('volunteer').controller('VolunteerProjects', function ($scope, $filter, crmApi, crmStatus, crmUiHelp, projectData, $location, volunteerBackbone, beneficiaries, $window) {
+  angular.module('volunteer').controller('VolunteerProjects', function ($scope, $filter, crmApi, crmStatus, crmUiHelp, projectData, $location, volunteerBackbone, beneficiaries, project_types, campaigns, $window) {
     // The ts() and hs() functions help load strings for this module.
     var ts = $scope.ts = CRM.ts('org.civicrm.volunteer');
     var hs = $scope.hs = crmUiHelp({file: 'CRM/volunteer/Projects'}); // See: templates/CRM/volunteer/Projects.hlp
@@ -68,6 +73,7 @@
     // TODO for VOL-276: Remove reference to beneficiaries object, based on deprecated API.
     $scope.beneficiaries = beneficiaries;
     $scope.campaignFilter = CRM.volunteer.campaignFilter;
+    $scope.project_types = project_types;
     $scope.needBase = CRM.url("civicrm/volunteer/need");
     $scope.assignBase = CRM.url("civicrm/volunteer/assign");
     $scope.urlPublicVolOppSearch = CRM.url('civicrm/vol/', '', 'front') + '#/volunteer/opportunities';

--- a/ang/volunteer/VolOppsCtrl.html
+++ b/ang/volunteer/VolOppsCtrl.html
@@ -27,6 +27,19 @@ Required vars: volOppData(), searchParams
             <input crm-ui-id="volOppSearchForm.date_end" crm-ui-datepicker="{time: false}" ng-model="searchParams.date_end" />
           </div>
 
+          <div crm-ui-field="{name: 'volOppSearchForm.type_id', title: ts('Type')}" class="crm-vol-opp-type">
+            <select
+                crm-ui-id="volOppSearchForm.type_id"
+                crm-ui-select="{minimumInputLength: 0, placeholder: ts('Select Volunteer Type(s)')}"
+                type="text"
+                multiple="multiple"
+                name="type_id"
+                ng-model="searchParams.type_id"
+                ng-options="key as value for (key , value) in project_types track by key"
+                class="big crm-form-text">
+            </select>
+          </div>
+
           <div crm-ui-field="{name: 'volOppSearchForm.role_id', title: ts('Role')}" class="crm-vol-opp-role">
             <select
               crm-ui-id="volOppSearchForm.role_id"
@@ -76,6 +89,17 @@ Required vars: volOppData(), searchParams
               ng-required="isProximitySearch">
             </select>
             <label crm-ui-for="volOppSearchForm.unit">of:</label>
+          </div>
+          <div crm-ui-field="{name: 'volOppSearchForm.loc_block_id', title: ts('Location')}" class="crm-vol-opp-location">
+            <select
+                crm-ui-id="volOppSearchForm.loc_block_id"
+                crm-ui-select="{placeholder: ts('Select Location'), allowClear:true}"
+                ng-model="searchParams.loc_block_id"
+                ng-change="changeLocBlock()"
+                ng-options="key as value for (key , value) in location_blocks track by key"
+                class="big crm-form-select">
+              <option />
+            </select>
           </div>
           <div crm-ui-field="{name: 'volOppSearchForm.street_address', title: ts('Street Address')}" class="crm-vol-opp-street">
             <input

--- a/api/v3/VolunteerUtil.php
+++ b/api/v3/VolunteerUtil.php
@@ -187,6 +187,19 @@ function civicrm_api3_volunteer_util_getsupportingdata($params) {
 }
 
 /**
+ * This method returns a list of project type options
+ *
+ * @param array $params
+ *   Not presently used.
+ * @return array
+ */
+function civicrm_api3_volunteer_util_getprojecttypeoptions($params) {
+  $result = CRM_Core_OptionGroup::values(CRM_Volunteer_Upgrader::volProjectTypeOptionGroupName, FALSE, FALSE, TRUE);
+
+  return civicrm_api3_create_success($result, "VolunteerUtil", "getprojecttypeoptions", $params);
+}
+
+/**
  * This method returns a list of beneficiaries
  *
  * @deprecated since version 2.3

--- a/volunteer.php
+++ b/volunteer.php
@@ -73,6 +73,15 @@ function volunteer_civicrm_navigationMenu(&$menu) {
   ));
 
   _volunteer_civix_insert_navigation_menu($menu, 'volunteer_volunteers', array(
+    'label' => E::ts('Configure Project Types'),
+    'name' => 'volunteer_config_project_types',
+    'url' => 'civicrm/admin/options/volunteer_project_type?reset=1',
+    'permission' => NULL,
+    'operator' => NULL,
+    'separator' => 0,
+  ));
+
+  _volunteer_civix_insert_navigation_menu($menu, 'volunteer_volunteers', array(
     'label' => E::ts('Configure Roles'),
     'name' => 'volunteer_config_roles',
     'url' => 'civicrm/admin/options/volunteer_role?reset=1',


### PR DESCRIPTION
Add a field named _Project Type_ to distinguish between various projects and expose on search screens.

Functional Specifications:
----------------------------------

- Add a field named _Project Type_. The field is of type _Alphanumeric_ and _Select_.
- In _New Volunteer Project_ page (/civicrm/vol/#/volunteer/manage/0), add the field between _Project Title_ and _Project Description_.
- In _Edit Volunteer Project_ page (/civicrm/vol/#/volunteer/manage/id), add the field so users can edit the field and change the value.
- In _Manage Projects_ page (/civicrm/vol/#/volunteer/manage):
- In the section _Find Volunteer Projects_, add the possibility to search on the field _Project Type_.
- Add the field between _Title_ and _Beneficiary_.
- Add the menu item _Configure Project Types_ between _Configure Project Relationships_ and _Configure Volunteer Settings_ to access https://sitename/civicrm/admin/options/volunteer_project_type?reset=1 so users can set values for this field. 
