### PR TITLE
Replace deprecated CRM_Core_OptionGroup::getValue()

### DIFF
--- a/CRM/Volunteer/BAO/NeedSearch.php
+++ b/CRM/Volunteer/BAO/NeedSearch.php
@@ -73,7 +73,7 @@ class CRM_Volunteer_BAO_NeedSearch {
       $flexibleNeed = civicrm_api3('VolunteerNeed', 'getsingle', array(
         'id' => $project->flexible_need_id,
       ));
-      if ($flexibleNeed['visibility_id'] === CRM_Core_OptionGroup::getValue('visibility', 'public', 'name')) {
+      if ($flexibleNeed['visibility_id'] === CRM_Core_PseudoConstant::getKey('CRM_Volunteer_BAO_Need', 'visibility_id', 'public')) {
         $needId = $flexibleNeed['id'];
         $results[$needId] = $flexibleNeed;
       }

--- a/CRM/Volunteer/BAO/Project.php
+++ b/CRM/Volunteer/BAO/Project.php
@@ -889,7 +889,7 @@ class CRM_Volunteer_BAO_Project extends CRM_Volunteer_DAO_Project {
       $result = civicrm_api3('VolunteerNeed', 'get', array(
         'is_active' => '1',
         'project_id' => $this->id,
-        'visibility_id' => CRM_Core_OptionGroup::getValue('visibility', 'public', 'name'),
+        'visibility_id' => CRM_Core_PseudoConstant::getKey('CRM_Volunteer_BAO_Need', 'visibility_id', 'public'),
         'options' => array(
           'sort' => 'start_time',
           'limit' => 0,

--- a/api/v3/VolunteerNeed.php
+++ b/api/v3/VolunteerNeed.php
@@ -58,7 +58,7 @@ function civicrm_api3_volunteer_need_create($params) {
 function _civicrm_api3_volunteer_need_create_spec(&$params) {
   $params['is_flexible']['api.default'] = 0;
   $params['is_active']['api.default'] = 1;
-  $params['visibility_id']['api.default'] = CRM_Core_OptionGroup::getValue('visibility', 'public', 'name');
+  $params['visibility_id']['api.default'] = CRM_Core_PseudoConstant::getKey('CRM_Volunteer_BAO_Need', 'visibility_id', 'public');
 
   // these metadata fields are managed; don't display them in the API explorer
   unset($params['created'], $params['last_updated']);

--- a/tests/phpunit/CRM/Volunteer/BAO/AssignmentTest.php
+++ b/tests/phpunit/CRM/Volunteer/BAO/AssignmentTest.php
@@ -15,7 +15,7 @@ class CRM_Volunteer_BAO_AssignmentTest extends VolunteerTestAbstract {
     $need = CRM_Core_DAO::createTestObject('CRM_Volunteer_BAO_Need', array(
       'is_active' => 1,
       'project_id' => $project->id,
-      'visibility_id' => CRM_Core_OptionGroup::getValue('visibility', 'public', 'name'),
+      'visibility_id' => CRM_Core_PseudoConstant::getKey('CRM_Volunteer_BAO_Need', 'visibility_id', 'public'),
     ));
     $this->assertObjectHasAttribute('id', $need, 'Failed to prepopulate Volunteer Need');
 

--- a/tests/phpunit/CRM/Volunteer/BAO/ProjectTest.php
+++ b/tests/phpunit/CRM/Volunteer/BAO/ProjectTest.php
@@ -65,7 +65,7 @@ class CRM_Volunteer_BAO_ProjectTest extends VolunteerTestAbstract {
     $need = CRM_Core_DAO::createTestObject('CRM_Volunteer_BAO_Need', array(
       'is_active' => 1,
       'project_id' => $project->id,
-      'visibility_id' => CRM_Core_OptionGroup::getValue('visibility', 'public', 'name'),
+      'visibility_id' => CRM_Core_PseudoConstant::getKey('CRM_Volunteer_BAO_Need', 'visibility_id', 'public'),
     ));
     $this->assertObjectHasAttribute('id', $need, 'Failed to prepopulate Volunteer Need');
 
@@ -84,7 +84,7 @@ class CRM_Volunteer_BAO_ProjectTest extends VolunteerTestAbstract {
     $need = CRM_Core_DAO::createTestObject('CRM_Volunteer_BAO_Need', array(
       'is_active' => 1,
       'project_id' => $project->id,
-      'visibility_id' => CRM_Core_OptionGroup::getValue('visibility', 'public', 'name'),
+      'visibility_id' => CRM_Core_PseudoConstant::getKey('CRM_Volunteer_BAO_Need', 'visibility_id', 'public'),
     ));
     $this->assertObjectHasAttribute('id', $need, 'Failed to prepopulate Volunteer Need');
 
@@ -102,7 +102,7 @@ class CRM_Volunteer_BAO_ProjectTest extends VolunteerTestAbstract {
     $need = CRM_Core_DAO::createTestObject('CRM_Volunteer_BAO_Need', array(
       'is_active' => 1,
       'project_id' => $project->id,
-      'visibility_id' => CRM_Core_OptionGroup::getValue('visibility', 'public', 'name'),
+      'visibility_id' => CRM_Core_PseudoConstant::getKey('CRM_Volunteer_BAO_Need', 'visibility_id', 'public'),
     ));
     $this->assertObjectHasAttribute('id', $need, 'Failed to prepopulate Volunteer Need');
 
@@ -123,7 +123,7 @@ class CRM_Volunteer_BAO_ProjectTest extends VolunteerTestAbstract {
       'is_flexible' => 0,
       'project_id' => $project->id,
       'role_id' => $role_id,
-      'visibility_id' => CRM_Core_OptionGroup::getValue('visibility', 'public', 'name'),
+      'visibility_id' => CRM_Core_PseudoConstant::getKey('CRM_Volunteer_BAO_Need', 'visibility_id', 'public'),
     ));
     $this->assertObjectHasAttribute('id', $need, 'Failed to prepopulate Volunteer Need');
 
@@ -143,7 +143,7 @@ class CRM_Volunteer_BAO_ProjectTest extends VolunteerTestAbstract {
       'is_active' => 1,
       'is_flexible' => 0,
       'project_id' => $project->id,
-      'visibility_id' => CRM_Core_OptionGroup::getValue('visibility', 'public', 'name'),
+      'visibility_id' => CRM_Core_PseudoConstant::getKey('CRM_Volunteer_BAO_Need', 'visibility_id', 'public'),
     ));
     $this->assertObjectHasAttribute('id', $need, 'Failed to prepopulate Volunteer Need');
 
@@ -161,7 +161,7 @@ class CRM_Volunteer_BAO_ProjectTest extends VolunteerTestAbstract {
     $need = CRM_Core_DAO::createTestObject('CRM_Volunteer_BAO_Need', array(
       'is_active' => 1,
       'project_id' => $project->id,
-      'visibility_id' => CRM_Core_OptionGroup::getValue('visibility', 'public', 'name'),
+      'visibility_id' => CRM_Core_PseudoConstant::getKey('CRM_Volunteer_BAO_Need', 'visibility_id', 'public'),
     ));
     $this->assertObjectHasAttribute('id', $need, 'Failed to prepopulate Volunteer Need');
 
@@ -224,7 +224,7 @@ class CRM_Volunteer_BAO_ProjectTest extends VolunteerTestAbstract {
       'quantity' => 5,
       'role_id' => $role_id,
       'start_time' => date('YmdHis', strtotime('tomorrow')),
-      'visibility_id' => CRM_Core_OptionGroup::getValue('visibility', 'public', 'name'),
+      'visibility_id' => CRM_Core_PseudoConstant::getKey('CRM_Volunteer_BAO_Need', 'visibility_id', 'public'),
     ));
 
     return array($project, $need, $role_id);


### PR DESCRIPTION
Civi 5.60 removes `CRM_Core_OptionGroup::getValue()`. This updates the code to the non-deprecated equivalent.

Note that I didn't get every single one in the tests - I'm not convinced any of my clients are using this, so I put in the effort needed to make sure crashes didn't happen.