### PR TITLE
Prevent hard-failure on latest CiviCRM

### DIFF
--- a/CRM/Volunteer/BAO/NeedSearch.php
+++ b/CRM/Volunteer/BAO/NeedSearch.php
@@ -73,7 +73,7 @@ class CRM_Volunteer_BAO_NeedSearch {
       $flexibleNeed = civicrm_api3('VolunteerNeed', 'getsingle', array(
         'id' => $project->flexible_need_id,
       ));
-      if ($flexibleNeed['visibility_id'] === CRM_Core_OptionGroup::getValue('visibility', 'public', 'name')) {
+      if (\CRM_Core_PseudoConstant::getName('CRM_Volunteer_BAO_Need', 'visibility_id', $flexibleNeed['visibility_id']) === 'public') {
         $needId = $flexibleNeed['id'];
         $results[$needId] = $flexibleNeed;
       }
@@ -276,7 +276,7 @@ class CRM_Volunteer_BAO_NeedSearch {
           $stateProvinceId = $api['api.LocBlock.getsingle']['api.Address.getsingle']['state_province_id'];
           $stateProvince = CRM_Core_PseudoConstant::stateProvince($stateProvinceId);
         }
-        
+
 
         $project['location'] = array(
           'city' => $api['api.LocBlock.getsingle']['api.Address.getsingle']['city'],

--- a/CRM/Volunteer/BAO/Project.php
+++ b/CRM/Volunteer/BAO/Project.php
@@ -424,8 +424,8 @@ class CRM_Volunteer_BAO_Project extends CRM_Volunteer_DAO_Project {
    * NOTE: related entities are not returned, just available for filtering.
    *
    * This function is invoked from within the web form layer and also from the
-   * API layer. 
-   * 
+   * API layer.
+   *
    * @see CRM_Volunteer_BAO_Project::create(), CRM_Volunteer_BAO_Project::buildContactJoin(), CRM_Volunteer_BAO_Project::buildProximityWhere()
    *
    * @param array $params
@@ -456,7 +456,7 @@ class CRM_Volunteer_BAO_Project extends CRM_Volunteer_DAO_Project {
         ->join('civicrm_address', 'INNER JOIN `civicrm_address` ON civicrm_address.id = loc.address_id')
         ->where(self::buildProximityWhere($params['proximity']));
     }
-    
+
     if (isset($params['is_active'])) {
       if (CRM_Volunteer_BAO_Project::isOff($params['is_active'])) {
         $params['is_active'] = 0;
@@ -889,7 +889,7 @@ class CRM_Volunteer_BAO_Project extends CRM_Volunteer_DAO_Project {
       $result = civicrm_api3('VolunteerNeed', 'get', array(
         'is_active' => '1',
         'project_id' => $this->id,
-        'visibility_id' => CRM_Core_OptionGroup::getValue('visibility', 'public', 'name'),
+        'visibility_id' => 'public',
         'options' => array(
           'sort' => 'start_time',
           'limit' => 0,

--- a/CRM/Volunteer/Form/VolunteerReport.mgd.php
+++ b/CRM/Volunteer/Form/VolunteerReport.mgd.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * This file declares managed database records of type "ReportTemplate" and
+ * This file declares managed database records of type "OptionValue" and
  * "ReportInstance." The records will be automatically inserted, updated, or
  * deleted from the database as appropriate. For more details, see
  * "hook_civicrm_managed" (at http://wiki.civicrm.org/confluence/display/CRMDOC/Hook+Reference)

--- a/api/v3/VolunteerNeed.php
+++ b/api/v3/VolunteerNeed.php
@@ -58,7 +58,7 @@ function civicrm_api3_volunteer_need_create($params) {
 function _civicrm_api3_volunteer_need_create_spec(&$params) {
   $params['is_flexible']['api.default'] = 0;
   $params['is_active']['api.default'] = 1;
-  $params['visibility_id']['api.default'] = CRM_Core_OptionGroup::getValue('visibility', 'public', 'name');
+  $params['visibility_id']['api.default'] = \CRM_Core_PseudoConstant::getKey('CRM_Volunteer_BAO_Need', 'visibility_id', 'public');
 
   // these metadata fields are managed; don't display them in the API explorer
   unset($params['created'], $params['last_updated']);

--- a/info.xml
+++ b/info.xml
@@ -8,10 +8,10 @@
     <author>Ginkgo Street Labs</author>
     <email>ginkgomzd@fastmail.com</email>
   </maintainer>
-  <releaseDate>2018-06-29</releaseDate>
+  <releaseDate>2023-05-15</releaseDate>
   <version>2.4.3</version>
   <compatibility>
-    <ver>5.28</ver>
+    <ver>5.29</ver>
   </compatibility>
   <comments>
     Developed by Ginkgo Street Labs and CiviCRM, LLC with contributions from the community. Special thanks to Friends of Georgia State Parks &amp; Historic Sites for funding the initial release, and to The Manhattan Neighborhood Network for funding the 1.4 release.

--- a/tests/phpunit/CRM/Volunteer/BAO/AssignmentTest.php
+++ b/tests/phpunit/CRM/Volunteer/BAO/AssignmentTest.php
@@ -15,7 +15,7 @@ class CRM_Volunteer_BAO_AssignmentTest extends VolunteerTestAbstract {
     $need = CRM_Core_DAO::createTestObject('CRM_Volunteer_BAO_Need', array(
       'is_active' => 1,
       'project_id' => $project->id,
-      'visibility_id' => CRM_Core_OptionGroup::getValue('visibility', 'public', 'name'),
+      'visibility_id' => 'public',
     ));
     $this->assertObjectHasAttribute('id', $need, 'Failed to prepopulate Volunteer Need');
 

--- a/tests/phpunit/CRM/Volunteer/BAO/ProjectTest.php
+++ b/tests/phpunit/CRM/Volunteer/BAO/ProjectTest.php
@@ -65,7 +65,7 @@ class CRM_Volunteer_BAO_ProjectTest extends VolunteerTestAbstract {
     $need = CRM_Core_DAO::createTestObject('CRM_Volunteer_BAO_Need', array(
       'is_active' => 1,
       'project_id' => $project->id,
-      'visibility_id' => CRM_Core_OptionGroup::getValue('visibility', 'public', 'name'),
+      'visibility_id' => 'public',
     ));
     $this->assertObjectHasAttribute('id', $need, 'Failed to prepopulate Volunteer Need');
 
@@ -84,7 +84,7 @@ class CRM_Volunteer_BAO_ProjectTest extends VolunteerTestAbstract {
     $need = CRM_Core_DAO::createTestObject('CRM_Volunteer_BAO_Need', array(
       'is_active' => 1,
       'project_id' => $project->id,
-      'visibility_id' => CRM_Core_OptionGroup::getValue('visibility', 'public', 'name'),
+      'visibility_id' => 'public',
     ));
     $this->assertObjectHasAttribute('id', $need, 'Failed to prepopulate Volunteer Need');
 
@@ -102,7 +102,7 @@ class CRM_Volunteer_BAO_ProjectTest extends VolunteerTestAbstract {
     $need = CRM_Core_DAO::createTestObject('CRM_Volunteer_BAO_Need', array(
       'is_active' => 1,
       'project_id' => $project->id,
-      'visibility_id' => CRM_Core_OptionGroup::getValue('visibility', 'public', 'name'),
+      'visibility_id' => 'public',
     ));
     $this->assertObjectHasAttribute('id', $need, 'Failed to prepopulate Volunteer Need');
 
@@ -123,7 +123,7 @@ class CRM_Volunteer_BAO_ProjectTest extends VolunteerTestAbstract {
       'is_flexible' => 0,
       'project_id' => $project->id,
       'role_id' => $role_id,
-      'visibility_id' => CRM_Core_OptionGroup::getValue('visibility', 'public', 'name'),
+      'visibility_id' => 'public',
     ));
     $this->assertObjectHasAttribute('id', $need, 'Failed to prepopulate Volunteer Need');
 
@@ -143,7 +143,7 @@ class CRM_Volunteer_BAO_ProjectTest extends VolunteerTestAbstract {
       'is_active' => 1,
       'is_flexible' => 0,
       'project_id' => $project->id,
-      'visibility_id' => CRM_Core_OptionGroup::getValue('visibility', 'public', 'name'),
+      'visibility_id' => 'public',,
     ));
     $this->assertObjectHasAttribute('id', $need, 'Failed to prepopulate Volunteer Need');
 
@@ -161,7 +161,7 @@ class CRM_Volunteer_BAO_ProjectTest extends VolunteerTestAbstract {
     $need = CRM_Core_DAO::createTestObject('CRM_Volunteer_BAO_Need', array(
       'is_active' => 1,
       'project_id' => $project->id,
-      'visibility_id' => CRM_Core_OptionGroup::getValue('visibility', 'public', 'name'),
+      'visibility_id' => 'public',,
     ));
     $this->assertObjectHasAttribute('id', $need, 'Failed to prepopulate Volunteer Need');
 
@@ -224,7 +224,7 @@ class CRM_Volunteer_BAO_ProjectTest extends VolunteerTestAbstract {
       'quantity' => 5,
       'role_id' => $role_id,
       'start_time' => date('YmdHis', strtotime('tomorrow')),
-      'visibility_id' => CRM_Core_OptionGroup::getValue('visibility', 'public', 'name'),
+      'visibility_id' => 'public',
     ));
 
     return array($project, $need, $role_id);

--- a/tests/phpunit/api/v3/VolunteerNeedTest.php
+++ b/tests/phpunit/api/v3/VolunteerNeedTest.php
@@ -25,7 +25,7 @@ class api_v3_VolunteerNeedTest extends VolunteerTestAbstract {
       "duration"      => 240,
       "is_flexible"   => 0,
       "quantity"      => 1,
-      "visibility_id" => CRM_Core_OptionGroup::getValue('visibility', 'public', 'name'),
+      "visibility_id" => 'public',
       "role_id"       => 1,
       "is_active"     => 1,
     );


### PR DESCRIPTION
There is still call in the extension to a function that has been progressively deprecated since 4.7 - which causes a fatal error on the ManageFees page if CiviVolunteer is enabled (in the js)

There are still some calls in the tests but they can't have been run in years as they would have failed on the deprecation warning