### PR TITLE
Update info.xml - tag release cos this hard-fails on 5.60+ without a new release

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -8,10 +8,10 @@
     <author>Ginkgo Street Labs</author>
     <email>ginkgomzd@fastmail.com</email>
   </maintainer>
-  <releaseDate>2018-06-29</releaseDate>
-  <version>2.4.3</version>
+  <releaseDate>2023-05-22</releaseDate>
+  <version>2.4.4</version>
   <compatibility>
-    <ver>5.28</ver>
+    <ver>5.60</ver>
   </compatibility>
   <comments>
     Developed by Ginkgo Street Labs and CiviCRM, LLC with contributions from the community. Special thanks to Friends of Georgia State Parks &amp; Historic Sites for funding the initial release, and to The Manhattan Neighborhood Network for funding the 1.4 release.


### PR DESCRIPTION
@ginkgomzd @homotechsual - we really need to tag this to avoid a hard fail on a very old long deprecated function that was removed. I incremented the version to 5.60 since earlier Civi versions are 'ok' at least on this issue so incrementing the version is more conservative

 There is another problem that persists even with this on saving events on the latest civi - but I would do a second release if we figure that out rather than delay getting this important fix out

