### PR TITLE
Fix deprecation warnings for permissions array in 5.71

### DIFF
--- a/CRM/Volunteer/Permission.php
+++ b/CRM/Volunteer/Permission.php
@@ -11,43 +11,44 @@ class CRM_Volunteer_Permission {
    * @return array Keyed by machine names with human-readable labels for values
    */
   public static function getVolunteerPermissions() {
-    $prefix = ts('CiviVolunteer', array('domain' => 'org.civicrm.volunteer')) . ': ';
+    $domain = array('domain' => 'org.civicrm.volunteer');
+    $prefix = ts('CiviVolunteer', $domain) . ': ';
     return array(
       'register to volunteer' => array(
-        $prefix . ts('register to volunteer', array('domain' => 'org.civicrm.volunteer')),
-        ts('Access public-facing volunteer opportunity listings and registration forms', array('domain' => 'org.civicrm.volunteer')),
+        'label' => $prefix . ts('register to volunteer', $domain),
+        'description' => ts('Access public-facing volunteer opportunity listings and registration forms', $domain),
       ),
       'log own hours' => array(
-        $prefix . ts('log own hours', array('domain' => 'org.civicrm.volunteer')),
-        ts('Access forms to self-report performed volunteer hours', array('domain' => 'org.civicrm.volunteer')),
+        'label' => $prefix . ts('log own hours', $domain),
+        'description' => ts('Access forms to self-report performed volunteer hours', $domain),
       ),
       'create volunteer projects' => array(
-        $prefix . ts('create volunteer projects', array('domain' => 'org.civicrm.volunteer')),
-        ts('Create a new volunteer project record in CiviCRM', array('domain' => 'org.civicrm.volunteer')),
+        'label' => $prefix . ts('create volunteer projects', $domain),
+        'description' => ts('Create a new volunteer project record in CiviCRM', $domain),
       ),
       'edit own volunteer projects' => array(
-        $prefix . ts('edit own volunteer projects', array('domain' => 'org.civicrm.volunteer')),
-        ts('Edit volunteer project records for which the user is specified as the Owner', array('domain' => 'org.civicrm.volunteer')),
+        'label' => $prefix . ts('edit own volunteer projects', $domain),
+        'description' => ts('Edit volunteer project records for which the user is specified as the Owner', $domain),
       ),
       'edit all volunteer projects' => array(
-        $prefix . ts('edit all volunteer projects', array('domain' => 'org.civicrm.volunteer')),
-        ts('Edit all volunteer project records, regardless of ownership', array('domain' => 'org.civicrm.volunteer')),
+        'label' => $prefix . ts('edit all volunteer projects', $domain),
+        'description' => ts('Edit all volunteer project records, regardless of ownership', $domain),
       ),
       'delete own volunteer projects' => array(
-        $prefix . ts('delete own volunteer projects', array('domain' => 'org.civicrm.volunteer')),
-        ts('Delete volunteer project records for which the user is specified as the Owner', array('domain' => 'org.civicrm.volunteer')),
+        'label' => $prefix . ts('delete own volunteer projects', $domain),
+        'description' => ts('Delete volunteer project records for which the user is specified as the Owner', $domain),
       ),
       'delete all volunteer projects' => array(
-        $prefix . ts('delete all volunteer projects', array('domain' => 'org.civicrm.volunteer')),
-        ts('Delete any volunteer project record, regardless of ownership', array('domain' => 'org.civicrm.volunteer')),
+        'label' => $prefix . ts('delete all volunteer projects', $domain),
+        'description' => ts('Delete any volunteer project record, regardless of ownership', $domain),
       ),
       'edit volunteer project relationships' => array(
-        $prefix . ts('edit volunteer project relationships', array('domain' => 'org.civicrm.volunteer')),
-        ts('Override system-wide default project relationships for a particular volunteer project', array('domain' => 'org.civicrm.volunteer')),
+        'label' => $prefix . ts('edit volunteer project relationships', $domain),
+        'description' => ts('Override system-wide default project relationships for a particular volunteer project', $domain),
       ),
       'edit volunteer registration profiles' => array(
-        $prefix . ts('edit volunteer registration profiles', array('domain' => 'org.civicrm.volunteer')),
-        ts('Override system-wide default registration profiles for a particular volunteer project', array('domain' => 'org.civicrm.volunteer')),
+        'label' => $prefix . ts('edit volunteer registration profiles', $domain),
+        'description' => ts('Override system-wide default registration profiles for a particular volunteer project', $domain),
       ),
     );
   }


### PR DESCRIPTION
As of CiviCRM 5.71, these warnings appear:

```
User deprecated function: Permission 'register to volunteer' should be declared with 'label' and 'description' keys. See https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_permission/ Caller: CRM_Core_Permission::assembleBasicPermissions in CRM_Core_Error::deprecatedWarning() (line 1129 of /var/www/html/vendor/civicrm/civicrm-core/CRM/Core/Error.php).

User deprecated function: Permission 'log own hours' should be declared with 'label' and 'description' keys. See https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_permission/ Caller: CRM_Core_Permission::assembleBasicPermissions in CRM_Core_Error::deprecatedWarning() (line 1129 of /var/www/html/vendor/civicrm/civicrm-core/CRM/Core/Error.php).

...
```

... along with similar warnings about the rest of the permissions.

I've not done any work with Civi extensions, but looking into the URL provided (https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_permission/), I believe the issue is related to how the permissions are configured in `CRM/Volunteer/Permission.php`:

```php
    return array(
      'register to volunteer' => array(
        $prefix . ts('register to volunteer', array('domain' => 'org.civicrm.volunteer')),
        ts('Access public-facing volunteer opportunity listings and registration forms', array('domain' => 'org.civicrm.volunteer')),
      ),
      'log own hours' => array(
        $prefix . ts('log own hours', array('domain' => 'org.civicrm.volunteer')),
        ts('Access forms to self-report performed volunteer hours', array('domain' => 'org.civicrm.volunteer')),
      ),
      ...
```

This array should, I think, be converted to:

```php
    return array(
      'register to volunteer' => array(
        'label' => $prefix . ts('register to volunteer', array('domain' => 'org.civicrm.volunteer')),
        'description' => ts('Access public-facing volunteer opportunity listings and registration forms', array('domain' => 'org.civicrm.volunteer')),
      ),
      'log own hours' => array(
        'label' => $prefix . ts('log own hours', array('domain' => 'org.civicrm.volunteer')),
        'description' => ts('Access forms to self-report performed volunteer hours', array('domain' => 'org.civicrm.volunteer')),
      ),
      ...
```

etc..  i.e. turn the non-associative array into an associative one with `label` and `description` keys.

This PR does that. 😄 (It also reduces the constant definition of `array('domain' => 'org.civicrm.volunteer')` and just does that once, similar to how the `$prefix` variable is used.)

