### PR TITLE
avoid template error with smarty4

### DIFF
--- a/templates/CRM/Volunteer/Page/Backbone/Define.tpl
+++ b/templates/CRM/Volunteer/Page/Backbone/Define.tpl
@@ -30,7 +30,7 @@
   <div id="help">
     {* VOL-47: The following is on one line intentionally. *}
     {ts domain='org.civicrm.volunteer'}Use this form to specify the number of volunteers needed for each role and time slot. If no opportunities are specified, volunteers will be considered to be generally available.{/ts}
-    {help id="volunteer-define" file="CRM/Volunteer/Page/Backbone/Define.hlp" isModulePermissionSupported=`$isModulePermissionSupported`}
+    {help id="volunteer-define" file="CRM/Volunteer/Page/Backbone/Define.hlp" isModulePermissionSupported="$isModulePermissionSupported"}
   </div>
   <form class="crm-block crm-form-block crm-event-manage-volunteer-form-block">
     <div id="crm-vol-define-scheduled-needs-region">


### PR DESCRIPTION
When using smarty4, the "Define Volunteer Opportunities",  "Assign Volunteers", and "Log Volunteer Hours" buttons don't work because the Define.tpl smarty template fails to load.

The failure of the Smarty template is due to the syntax: 

```
{help id="volunteer-define" file="CRM/Volunteer/Page/Backbone/Define.hlp" isModulePermissionSupported=│projects[osdi-client][download][revision] = "422cd55498b2d888ee72364962e6a831da9a6796"
`$isModulePermissionSupported`} 
```

Backticks should be enclosed in double quotes. And also, they are only necessary if the variable has a period.
