### PR TITLE
ensure buttons have non-white background

### DIFF
--- a/css/volunteer_events.css
+++ b/css/volunteer_events.css
@@ -9,3 +9,7 @@
 .crm-span-button .crm-span-button-text {
   padding: 2px 7px 2px 20px;
 }
+
+div#crm-volunteer-event-action-items > span.crm-span-button {
+  background-color: rgb(62, 62, 62);
+}


### PR DESCRIPTION
When using the islands theme, the buttons to Define Volunteer, Opportunities Assign Volunteers, and Log Volunteer Hours on the event tab appear with a white background, which makes them hard to read. This css fix makes them  more visible.