### PR TITLE
Update hook_civicrm_fieldOptions to handle other contexts

### DIFF
--- a/volunteer.php
+++ b/volunteer.php
@@ -528,7 +528,12 @@ function volunteer_civicrm_angularModules(&$angularModules) {
  * @param $params
  */
 function volunteer_civicrm_fieldOptions($entity, $field, &$options, $params) {
-  if ($entity == "UFJoin" && $field == "entity_table" && $params['context'] == "validate") {
-    $options[CRM_Volunteer_DAO_Project::getTableName()] = CRM_Volunteer_DAO_Project::getTableName();
+  if ($entity == 'UFJoin' && $field == 'entity_table') {
+    if ($params['context'] == 'validate') {
+      $options[CRM_Volunteer_DAO_Project::getTableName()] = CRM_Volunteer_DAO_Project::getTableName();
+    }
+    else {
+      $options[CRM_Volunteer_DAO_Project::getTableName()] = 'Project';
+    }
   }
 }


### PR DESCRIPTION
This hook signature is changing, and will not always be called with 'validate' context when this extension expects it to.
This is the minimal safe/compat fix.

See https://github.com/civicrm/civicrm-core/pull/30986