### PR TITLE
Fix #613 - Ensure 'org.civicrm.volunteer' exists

### DIFF
--- a/CRM/Volunteer/Page/Angular.php
+++ b/CRM/Volunteer/Page/Angular.php
@@ -7,6 +7,9 @@ class CRM_Volunteer_Page_Angular extends \CRM_Core_Page {
       'template' => 'CRM/common/notifications.tpl',
     ));
     CRM_Volunteer_Angular::load('/volunteer/manage');
+    // Ensure this setting exists even if it's an empty object (https://github.com/civicrm/org.civicrm.volunteer/issues/613)
+    Civi::resources()
+      ->addVars('org.civicrm.volunteer', []);
     parent::run();
   }
 

--- a/volunteer.php
+++ b/volunteer.php
@@ -499,25 +499,6 @@ function _volunteer_isVolListingApiCall($entity, $action) {
 }
 
 /**
- * Implements hook_civicrm_angularModules().
- *
- * @param array $angularModules
- *   An array containing a list of all Angular modules.
- */
-function volunteer_civicrm_angularModules(&$angularModules) {
-
-  // DEPRECATED clientside variable CRM.vars['org.civicrm.volunteer'].currentContactId
-  // Not used by this extension but kept around in case others depend on it.
-  // They should be updated to use CRM.config.cid
-  CRM_Core_Resources::singleton()
-    ->addVars('org.civicrm.volunteer', array(
-      'currentContactId' => CRM_Core_Session::singleton()->getLoggedInContactID()
-    ));
-
-  return;
-}
-
-/**
  * This is an implementation of hook_civicrm_fieldOptions
  * It includes `civicrm_volunteer_project` in the whitelist
  * of tables allowed to have UFJoins


### PR DESCRIPTION
Fixes #613 - as of https://github.com/civicrm/civicrm-core/pull/27783 `hook_civicrm_angularModules()` is not called every time, so should not contain any code that must be executed on every page load.