### PR TITLE
Ensure html attributes are escaped in templates

### DIFF
--- a/templates/CRM/Volunteer/Form/Log.tpl
+++ b/templates/CRM/Volunteer/Form/Log.tpl
@@ -33,7 +33,7 @@
       <div class="crm-grid-cell"></div>
       <div class="crm-grid-cell">
         {ts domain='org.civicrm.volunteer'}Contact{/ts}
-        <span class="crm-marker" title="{ts domain='org.civicrm.volunteer'}This field is required.{/ts}">*</span>
+        <span class="crm-marker" title="{ts escape='htmlattribute' domain='org.civicrm.volunteer'}This field is required.{/ts}">*</span>
       </div>
       <div class="crm-grid-cell">{ts domain='org.civicrm.volunteer'}Role{/ts}</div>
       <div class="crm-grid-cell">{ts domain='org.civicrm.volunteer'}Start Date{/ts}</div>
@@ -44,7 +44,7 @@
              fname="actual_duration" class="action-icon"
              title="{ts domain='org.civicrm.volunteer'}Click here to copy the Actual Duration value in row one to ALL rows.{/ts}" />
         {ts}Actual Duration <br/> (in minutes){/ts}
-        <span class="crm-marker" title="{ts domain='org.civicrm.volunteer'}This field is required.{/ts}">*</span>
+        <span class="crm-marker" title="{ts escape='htmlattribute' domain='org.civicrm.volunteer'}This field is required.{/ts}">*</span>
       </div>
       <div class="crm-grid-cell"><img src="{$config->resourceBase}i/copy.png"
                                       alt="{ts domain='org.civicrm.volunteer'}Click to copy Volunteer Status from row one to all rows.{/ts}"

--- a/templates/CRM/Volunteer/Page/Backbone/Assign.tpl
+++ b/templates/CRM/Volunteer/Page/Backbone/Assign.tpl
@@ -36,7 +36,7 @@
     <span class="icon crm-vol-drag"></span>
     <a target="_blank" href="<%= contactUrl(contact_id) %>"><%- display_name %></a>
     {literal}<%if (details){%><a href="#" class="icon crm-vol-info"> </a><%}%>{/literal}
-    <div class="crm-vol-menu"><a class="crm-vol-menu-button" href="#" title="{ts domain='org.civicrm.volunteer'}Actions{/ts}"><span></span></a></div>
+    <div class="crm-vol-menu"><a class="crm-vol-menu-button" href="#" title="{ts escape='htmlattribute' domain='org.civicrm.volunteer'}Actions{/ts}"><span></span></a></div>
   </td>
   <td><%= email %></td>
   <td><%= phone %></td>
@@ -47,7 +47,7 @@
     <span class="icon crm-vol-drag"></span>
     <a target="_blank" href="<%= contactUrl(contact_id) %>"><%- display_name %></a>
     {literal}<%if (details){%><a href="#" class="icon crm-vol-info"> </a><%}%>{/literal}
-    <div class="crm-vol-menu"><a class="crm-vol-menu-button" href="#" title="{ts domain='org.civicrm.volunteer'}Actions{/ts}"><span></span></a></div>
+    <div class="crm-vol-menu"><a class="crm-vol-menu-button" href="#" title="{ts escape='htmlattribute' domain='org.civicrm.volunteer'}Actions{/ts}"><span></span></a></div>
   </td>
 </script>
 
@@ -64,7 +64,7 @@
       <div class="crm-vol-circle"><div class="icon"></div></div>
     </div>
   </div>
-  <h3><%= pseudoConstant.volunteer_role[role_id] %> (<%= quantity || '{ts domain='org.civicrm.volunteer' escape='js'}Any{/ts}' %>): <%= display_time %></h3>
+  <h3><%= pseudoConstant.volunteer_role[role_id] %> (<%= quantity || '{ts escape='htmlattribute' domain='org.civicrm.volunteer' escape='js'}Any{/ts}' %>): <%= display_time %></h3>
   <table class="row-highlight">
     <thead><tr>
       <th>{ts domain='org.civicrm.volunteer'}Name{/ts}</th>
@@ -84,7 +84,7 @@
     <tbody class="crm-vol-assignment-list"></tbody>
   </table>
   <hr style="margin: 1em 1px;"/>
-  <input name="add-volunteer" class="crm-action-menu action-icon-plus" placeholder="{ts domain='org.civicrm.volunteer' escape='js'}Add Volunteer{/ts}..." style="width: 100%; max-width: 30em;" />
+  <input name="add-volunteer" class="crm-action-menu action-icon-plus" placeholder="{ts escape='htmlattribute' domain='org.civicrm.volunteer' escape='js'}Add Volunteer{/ts}..." style="width: 100%; max-width: 30em;" />
 </script>
 
 <script type="text/template" id="crm-vol-menu-tpl">

--- a/templates/CRM/Volunteer/Page/Backbone/Define.tpl
+++ b/templates/CRM/Volunteer/Page/Backbone/Define.tpl
@@ -118,7 +118,7 @@
   </td>
   <td><input type="checkbox" name="visibility_id" value="<%= visibilityValue %>"></td>
   <td><input type="checkbox" name="is_active" value="1"></td>
-  <td><a href="#" class="crm-vol-del action-item crm-hover-button small-popup" title="{ts domain='org.civicrm.volunteer'}Delete{/ts}">{ts}Delete{/ts}</a></td>
+  <td><a href="#" class="crm-vol-del action-item crm-hover-button small-popup" title="{ts escape='htmlattribute' domain='org.civicrm.volunteer'}Delete{/ts}">{ts}Delete{/ts}</a></td>
 </script>
 
 <script type="text/template" id="crm-vol-define-flexible-need-tpl">

--- a/templates/CRM/Volunteer/Page/Backbone/Search.tpl
+++ b/templates/CRM/Volunteer/Page/Backbone/Search.tpl
@@ -48,10 +48,10 @@
 </script>
 
 <script type="text/template" id="crm-vol-search-result-tpl">
-  <table summary="{ts domain='org.civicrm.volunteer'}Search results listings.{/ts}" class="selector row-highlight">
+  <table summary="{ts escape='htmlattribute' domain='org.civicrm.volunteer'}Search results listings.{/ts}" class="selector row-highlight">
     <thead class="sticky">
       <tr>
-        <th scope="col"><input type="checkbox" name="select_all_contacts" title="{ts domain='org.civicrm.volunteer'}Select All Rows{/ts}" /></th>
+        <th scope="col"><input type="checkbox" name="select_all_contacts" title="{ts escape='htmlattribute' domain='org.civicrm.volunteer'}Select All Rows{/ts}" /></th>
         <th scope="col">{ts domain='org.civicrm.volunteer'}Name{/ts}</th>
         <th scope="col">{ts domain='org.civicrm.volunteer'}City{/ts}</th>
         <th scope="col">{ts domain='org.civicrm.volunteer'}State{/ts}</th>

--- a/templates/CRM/Volunteer/Page/Roster.tpl
+++ b/templates/CRM/Volunteer/Page/Roster.tpl
@@ -16,17 +16,17 @@
           {if $assignment.email}
             {assign var='emailParams' value="action=add&reset=1&atype=3&cid=`$assignment.contact_id`"}
             <a class="button" href="{crmURL p='civicrm/activity/email/add' q=$emailParams}"
-               title="{ts 1=$assignment.name domain='org.civicrm.volunteer'}Send %1 an email.{/ts}">
+               title="{ts escape='htmlattribute' 1=$assignment.name domain='org.civicrm.volunteer'}Send %1 an email.{/ts}">
                <i class="crm-i fa-envelope-o"></i>
                {ts}Email{/ts}</a>
           {/if}
           {if $assignment.phone}
             <a class="button" href="tel:{$assignment.phone}"
-               title="{ts 1=$assignment.name domain='org.civicrm.volunteer'}Telephone %1.{/ts}">
+               title="{ts escape='htmlattribute' 1=$assignment.name domain='org.civicrm.volunteer'}Telephone %1.{/ts}">
             <i class="crm-i fa-phone"></i>
             {ts}Call{/ts}</a>
             <a class="button" href="sms:{$assignment.phone}"
-               title="{ts 1=$assignment.name domain='org.civicrm.volunteer'}Send %1 an SMS message.{/ts}">
+               title="{ts escape='htmlattribute' 1=$assignment.name domain='org.civicrm.volunteer'}Send %1 an SMS message.{/ts}">
             <i class="crm-i fa-mobile"></i>
             {ts}SMS{/ts}</a>
             {/if}


### PR DESCRIPTION
This adds escape='htmlattribute' to all translations within tags, which ensures any special characters in the translated string
are properly escaped and don't break out of the quotes or cause other problems.

See https://github.com/civicrm/civicrm-core/pull/26792

Note: This requires CiviCRM 5.65 at minimum.