### PR TITLE
Remove calls to deprecated CRM_Utils_Array::value

### DIFF
--- a/CRM/Volunteer/BAO/Activity.php
+++ b/CRM/Volunteer/BAO/Activity.php
@@ -50,7 +50,7 @@ abstract class CRM_Volunteer_BAO_Activity extends CRM_Activity_DAO_Activity {
 
       $fields = civicrm_api3('CustomField', 'get', $params);
 
-      if (CRM_Utils_Array::value('count', $fields) < 1) {
+      if (($fields['count'] ?? 0) < 1) {
         CRM_Core_Error::fatal('CiviVolunteer-defined custom fields appear to be missing (custom field group' . static::CUSTOM_GROUP_NAME . ').');
       }
 

--- a/CRM/Volunteer/BAO/Assignment.php
+++ b/CRM/Volunteer/BAO/Assignment.php
@@ -112,15 +112,15 @@ class CRM_Volunteer_BAO_Assignment extends CRM_Volunteer_BAO_Activity {
     $whereClause = NULL;
     foreach ($filtered_params as $key => $value) {
 
-      if (CRM_Utils_Array::value($key, $activity_fields)) {
+      if (!empty($activity_fields[$key])) {
         $dataType = CRM_Utils_Type::typeToString($activity_fields[$key]['type']);
         $fieldName = $activity_fields[$key]['name'];
         $tableName = CRM_Activity_DAO_Activity::getTableName();
-      } elseif (CRM_Utils_Array::value($key, $contact_fields)) {
+      } elseif (!empty($contact_fields[$key])) {
         $dataType = CRM_Utils_Type::typeToString($contact_fields[$key]['type']);
         $fieldName = $contact_fields[$key]['name'];
         $tableName = CRM_Contact_DAO_Contact::getTableName();
-      } elseif (CRM_Utils_Array::value($key, $custom_fields)) {
+      } elseif (!empty($custom_fields[$key])) {
         $dataType = $custom_fields[$key]['data_type'];
         $fieldName = $custom_fields[$key]['column_name'];
         $tableName = $customTableName;
@@ -250,7 +250,7 @@ class CRM_Volunteer_BAO_Assignment extends CRM_Volunteer_BAO_Activity {
     $project = CRM_Volunteer_BAO_Project::retrieveByID($need['project_id']);
 
     //copy over duration to Volunteer activity
-    $defaults['duration'] = CRM_Utils_Array::value('duration', $need, 'null');
+    $defaults['duration'] = $need['duration'] ?? 'null';
 
     $defaults['campaign_id'] = $project ? $project->campaign_id : '';
     // Force NULL campaign ids to be empty strings, since the API ignores NULL values.
@@ -258,16 +258,16 @@ class CRM_Volunteer_BAO_Assignment extends CRM_Volunteer_BAO_Activity {
       $defaults['campaign_id'] = '';
     }
     if (empty($params['volunteer_role_id'])) {
-      $defaults['volunteer_role_id'] = CRM_Utils_Array::value('role_id', $need, 'null');
+      $defaults['volunteer_role_id'] = $need['role_id'] ?? 'null';
     }
     if ($op === CRM_Core_Action::ADD) {
-      $defaults['time_scheduled_minutes'] = CRM_Utils_Array::value('duration', $need);
+      $defaults['time_scheduled_minutes'] = $need['duration'] ?? NULL;
       $defaults['target_contact_id'] = CRM_Volunteer_BAO_Project::getContactsByRelationship($project->id, 'volunteer_beneficiary');
 
       // If the related entity doesn't provide a good default, use tomorrow.
       if (empty($params['activity_date_time'])) {
         $tomorrow = date('Y-m-d H:i:s', strtotime('tomorrow'));
-        $defaults['activity_date_time'] = CRM_Utils_Array::value('start_time', $project->getEntityAttributes(), $tomorrow);
+        $defaults['activity_date_time'] = $project->getEntityAttributes()['start_time'] ?? $tomorrow;
       }
 
       if (empty($params['subject'])) {

--- a/CRM/Volunteer/BAO/Commendation.php
+++ b/CRM/Volunteer/BAO/Commendation.php
@@ -36,17 +36,17 @@ class CRM_Volunteer_BAO_Commendation extends CRM_Volunteer_BAO_Activity {
       'status_id' => CRM_Utils_Array::key('Completed', $activity_statuses),
     );
 
-    $aid = CRM_Utils_Array::value('aid', $params);
+    $aid = $params['aid'] ?? NULL;
     if ($aid) {
       $api_params['id'] = $aid;
     }
 
-    $cid = CRM_Utils_Array::value('cid', $params);
+    $cid = $params['cid'] ?? NULL;
     if ($cid) {
       $api_params['target_contact_id'] = $cid;
     }
 
-    $vid = CRM_Utils_Array::value('vid', $params);
+    $vid = $params['vid'] ?? NULL;
     if ($vid) {
       $project = CRM_Volunteer_BAO_Project::retrieveByID($vid);
       $api_params['subject'] = ts('Volunteer Commendation for %1', array('1' => $project->title, 'domain' => 'org.civicrm.volunteer'));
@@ -57,7 +57,7 @@ class CRM_Volunteer_BAO_Commendation extends CRM_Volunteer_BAO_Activity {
     }
 
     if (array_key_exists('details', $params)) {
-      $api_params['details'] = CRM_Utils_Array::value('details', $params);
+      $api_params['details'] = $params['details'] ?? NULL;
     }
 
     return civicrm_api3('Activity', 'create', $api_params);
@@ -73,9 +73,9 @@ class CRM_Volunteer_BAO_Commendation extends CRM_Volunteer_BAO_Activity {
    */
   private static function requiredParamsArePresent($params) {
     if (
-      CRM_Utils_Array::value('aid', $params) || ( // activity id
-        CRM_Utils_Array::value('cid', $params) && // contact id
-        CRM_Utils_Array::value('vid', $params) // volunteer project id
+      !empty($params['aid']) || ( // activity id
+        !empty($params['cid']) && // contact id
+        !empty($params['vid']) // volunteer project id
       )
     ) {
       return TRUE;
@@ -131,15 +131,15 @@ class CRM_Volunteer_BAO_Commendation extends CRM_Volunteer_BAO_Activity {
     $whereClause = NULL;
     foreach ($filtered_params as $key => $value) {
 
-      if (CRM_Utils_Array::value($key, $activity_fields)) {
+      if (!empty($activity_fields[$key])) {
         $dataType = CRM_Utils_Type::typeToString($activity_fields[$key]['type']);
         $fieldName = $activity_fields[$key]['name'];
         $tableName = CRM_Activity_DAO_Activity::getTableName();
-      } elseif (CRM_Utils_Array::value($key, $contact_fields)) {
+      } elseif (!empty($contact_fields[$key])) {
         $dataType = CRM_Utils_Type::typeToString($contact_fields[$key]['type']);
         $fieldName = $contact_fields[$key]['name'];
         $tableName = CRM_Contact_DAO_Contact::getTableName();
-      } elseif (CRM_Utils_Array::value($key, $custom_fields)) {
+      } elseif (!empty($custom_fields[$key])) {
         $dataType = $custom_fields[$key]['data_type'];
         $fieldName = $custom_fields[$key]['column_name'];
         $tableName = $customTableName;

--- a/CRM/Volunteer/BAO/NeedSearch.php
+++ b/CRM/Volunteer/BAO/NeedSearch.php
@@ -109,8 +109,8 @@ class CRM_Volunteer_BAO_NeedSearch {
    * @return boolean
    */
   private function needFitsDateCriteria(array $need) {
-    $needStartTime = strtotime(CRM_Utils_Array::value('start_time', $need));
-    $needEndTime = strtotime(CRM_Utils_Array::value('end_time', $need));
+    $needStartTime = strtotime(($need['start_time'] ?? ''));
+    $needEndTime = strtotime(($need['end_time'] ?? ''));
 
     // There are no date-related search criteria, so we're done here.
     if ($this->searchParams['need']['date_start'] === FALSE && $this->searchParams['need']['date_end'] === FALSE) {
@@ -177,17 +177,17 @@ class CRM_Volunteer_BAO_NeedSearch {
   private function setSearchParams($userSearchParams) {
     $this->setSearchDateParams($userSearchParams);
 
-    $projectId = CRM_Utils_Array::value('project', $userSearchParams);
+    $projectId = $userSearchParams['project'] ?? NULL;
     if (CRM_Utils_Type::validate($projectId, 'Positive', FALSE)) {
       $this->searchParams['project']['id'] = $projectId;
     }
 
-    $proximity = CRM_Utils_Array::value('proximity', $userSearchParams);
+    $proximity = $userSearchParams['proximity'] ?? NULL;
     if (is_array($proximity)) {
       $this->searchParams['project']['proximity'] = $proximity;
     }
 
-    $beneficiary = CRM_Utils_Array::value('beneficiary', $userSearchParams);
+    $beneficiary = $userSearchParams['beneficiary'] ?? NULL;
     if ($beneficiary) {
       if (!array_key_exists('project_contacts', $this->searchParams['project'])) {
         $this->searchParams['project']['project_contacts'] = array();
@@ -196,7 +196,7 @@ class CRM_Volunteer_BAO_NeedSearch {
       $this->searchParams['project']['project_contacts']['volunteer_beneficiary'] = $beneficiary;
     }
 
-    $role = CRM_Utils_Array::value('role_id', $userSearchParams);
+    $role = $userSearchParams['role_id'] ?? NULL;
     if ($role) {
       $this->searchParams['need']['role_id'] = is_array($role) ? $role : explode(',', $role);
     }
@@ -212,8 +212,8 @@ class CRM_Volunteer_BAO_NeedSearch {
    *     - date_end: date
    */
   private function setSearchDateParams($userSearchParams) {
-    $this->searchParams['need']['date_start'] = strtotime(CRM_Utils_Array::value('date_start', $userSearchParams));
-    $date_end = strtotime(CRM_Utils_Array::value('date_end', $userSearchParams));
+    $this->searchParams['need']['date_start'] = strtotime(($userSearchParams['date_start'] ?? ''));
+    $date_end = strtotime(($userSearchParams['date_end'] ?? ''));
     if ($date_end) {
       // The end date is entered by the user as YYYY-MM-DD. Then, strtotime
       // converts it to a time stamp represending YYYY-MM-DD 00:00:00.

--- a/CRM/Volunteer/BAO/Project.php
+++ b/CRM/Volunteer/BAO/Project.php
@@ -263,7 +263,7 @@ class CRM_Volunteer_BAO_Project extends CRM_Volunteer_DAO_Project {
    * @return CRM_Volunteer_BAO_Project object
    */
   public static function create(array $params) {
-    $projectId = CRM_Utils_Array::value('id', $params);
+    $projectId = $params['id'] ?? NULL;
     $op = empty($projectId) ? CRM_Core_Action::ADD : CRM_Core_Action::UPDATE;
 
     if (!empty($params['check_permissions']) && !CRM_Volunteer_Permission::checkProjectPerms($op, $projectId)) {
@@ -434,8 +434,8 @@ class CRM_Volunteer_BAO_Project extends CRM_Volunteer_DAO_Project {
   public static function retrieve(array $params) {
     $result = array();
 
-    $projectId = CRM_Utils_Array::value('id', $params);
-    $checkPerms = CRM_Utils_Array::value('check_permissions', $params);
+    $projectId = $params['id'] ?? NULL;
+    $checkPerms = $params['check_permissions'] ?? NULL;
     if ($checkPerms && !self::allowedToRetrieve($projectId)) {
       CRM_Utils_System::permissionDenied();
       return;
@@ -678,7 +678,7 @@ class CRM_Volunteer_BAO_Project extends CRM_Volunteer_DAO_Project {
         'return' => 'id',
         'version' => 3,
       ));
-      if (CRM_Utils_Array::value('is_error', $flexibleNeed) !== 1) {
+      if (($flexibleNeed['is_error'] ?? NULL) !== 1) {
         $result = (int) $flexibleNeed;
       }
     }
@@ -870,7 +870,7 @@ class CRM_Volunteer_BAO_Project extends CRM_Volunteer_DAO_Project {
               'return' => array('end_date'),
             );
             $result = civicrm_api3('Event', 'get', $params);
-            $this->end_date = CRM_Utils_Array::value('end_date', $result['values'][$this->entity_id]);
+            $this->end_date = $result['values'][$this->entity_id]['end_date'] ?? NULL;
             break;
         }
       }
@@ -919,10 +919,10 @@ class CRM_Volunteer_BAO_Project extends CRM_Volunteer_DAO_Project {
       }
 
       foreach ($this->needs as $need) {
-        if (CRM_Utils_Array::value('is_flexible', $need) == '1') {
+        if (!empty($need['is_flexible'])) {
           $roles[CRM_Volunteer_BAO_Need::FLEXIBLE_ROLE_ID] = CRM_Volunteer_BAO_Need::getFlexibleRoleLabel();
         } else {
-          $role_id = CRM_Utils_Array::value('role_id', $need);
+          $role_id = $need['role_id'] ?? NULL;
           $roles[$role_id] = CRM_Core_OptionGroup::getLabel(
             CRM_Volunteer_BAO_Assignment::ROLE_OPTION_GROUP,
             $role_id
@@ -961,7 +961,7 @@ class CRM_Volunteer_BAO_Project extends CRM_Volunteer_DAO_Project {
             // 1) start after now,
             strtotime($need['start_time']) >= $now
             // 2) end after now, or
-            || strtotime(CRM_Utils_Array::value('end_time', $need)) >= $now
+            || strtotime($need['end_time'] ?? '') >= $now
             // 3) be open until filled
             || (empty($need['end_time']) && empty($need['duration']))
           )

--- a/CRM/Volunteer/Form/IncludeProfile.php
+++ b/CRM/Volunteer/Form/IncludeProfile.php
@@ -7,7 +7,7 @@
  */
 class CRM_Volunteer_Form_IncludeProfile extends CRM_Core_Form {
   function buildQuickForm() {
-    $profileCount = CRM_Utils_Array::value('profileCount', $_GET, FALSE);
+    $profileCount = $_GET['profileCount'] ?? FALSE;
     self::buildProfileWidget($this, $profileCount);
     $this->assign('profileCount', $profileCount);
 

--- a/CRM/Volunteer/Form/Log.php
+++ b/CRM/Volunteer/Form/Log.php
@@ -235,7 +235,7 @@ class CRM_Volunteer_Form_Log extends CRM_Core_Form {
     foreach ($this->_volunteerData as $data) {
       $defaults['field'][$i]['scheduled_duration'] = $data['time_scheduled_minutes'];
       $defaults['field'][$i]['actual_duration'] = $data['time_completed_minutes'];
-      $defaults['field'][$i]['volunteer_role'] = CRM_Utils_Array::value($data['volunteer_role_id'], $volunteerRole);
+      $defaults['field'][$i]['volunteer_role'] = $volunteerRole[$data['volunteer_role_id']] ?? NULL;
       $defaults['field'][$i]['volunteer_status'] = $data['status_id'];
       $defaults['field'][$i]['activity_id'] = $data['id'];
       $defaults['field'][$i]['start_date'] = $data['activity_date_time'];
@@ -273,8 +273,8 @@ class CRM_Volunteer_Form_Log extends CRM_Core_Form {
         $volunteer = array(
           'status_id' => $value['volunteer_status'],
           'id' => $value['activity_id'],
-          'time_completed_minutes' => CRM_Utils_Array::value('actual_duration', $value),
-          'time_scheduled_minutes' => CRM_Utils_Array::value('scheduled_duration', $value),
+          'time_completed_minutes' => $value['actual_duration'] ?? NULL,
+          'time_scheduled_minutes' => $value['scheduled_duration'] ?? NULL,
         );
         CRM_Volunteer_BAO_Assignment::createVolunteerActivity($volunteer);
       } else {
@@ -285,9 +285,9 @@ class CRM_Volunteer_Form_Log extends CRM_Core_Form {
           'status_id' => $value['volunteer_status'],
           'subject' => $this->_title . ' Volunteering',
           'volunteer_need_id' => $flexibleNeedId,
-          'volunteer_role_id' => CRM_Utils_Array::value('volunteer_role', $value),
-          'time_completed_minutes' => CRM_Utils_Array::value('actual_duration', $value),
-          'time_scheduled_minutes' => CRM_Utils_Array::value('scheduled_duration', $value),
+          'volunteer_role_id' => $value['volunteer_role'] ?? NULL,
+          'time_completed_minutes' => $value['actual_duration'] ?? NULL,
+          'time_scheduled_minutes' => $value['scheduled_duration'] ?? NULL,
         );
         if (!empty($value['start_date'])) {
           $volunteer['activity_date_time'] = CRM_Utils_Date::processDate($value['start_date'], $value['start_date_time'], TRUE);

--- a/CRM/Volunteer/Form/Settings.php
+++ b/CRM/Volunteer/Form/Settings.php
@@ -230,18 +230,18 @@ class CRM_Volunteer_Form_Settings extends CRM_Core_Form {
   function setDefaultValues() {
     $defaults = array();
 
-    $defaults['volunteer_project_default_is_active'] = CRM_Utils_Array::value('volunteer_project_default_is_active', $this->_settings);
-    $defaults['volunteer_project_default_campaign'] = CRM_Utils_Array::value('volunteer_project_default_campaign', $this->_settings);
-    $defaults['volunteer_project_default_locblock'] = CRM_Utils_Array::value('volunteer_project_default_locblock', $this->_settings);
+    $defaults['volunteer_project_default_is_active'] = $this->_settings['volunteer_project_default_is_active'] ?? NULL;
+    $defaults['volunteer_project_default_campaign'] = $this->_settings['volunteer_project_default_campaign'] ?? NULL;
+    $defaults['volunteer_project_default_locblock'] = $this->_settings['volunteer_project_default_locblock'] ?? NULL;
 
     // Break the profiles out into their own fields
-    $profiles = CRM_Utils_Array::value('volunteer_project_default_profiles', $this->_settings);
+    $profiles = $this->_settings['volunteer_project_default_profiles'] ?? NULL;
     foreach (CRM_Volunteer_BAO_Project::getProjectProfileAudienceTypes() as $audience) {
-      $defaults["volunteer_project_default_profiles_" . $audience['type']] = CRM_Utils_Array::value($audience['type'], $profiles, array());
+      $defaults["volunteer_project_default_profiles_" . $audience['type']] = $profiles[$audience['type']] ?? [];
     }
 
     // Break out contact defaults into their own fields
-    $defaultContacts = CRM_Utils_Array::value('volunteer_project_default_contacts', $this->_settings);
+    $defaultContacts = $this->_settings['volunteer_project_default_contacts'] ?? NULL;
     foreach ($defaultContacts as $name => $data) {
       $mode = $data['mode'];
       $defaults["volunteer_project_default_contacts_mode_{$name}"] = $mode;
@@ -252,9 +252,9 @@ class CRM_Volunteer_Form_Settings extends CRM_Core_Form {
     }
 
     // General Settings
-    $defaults['volunteer_general_campaign_filter_type'] = CRM_Utils_Array::value('volunteer_general_campaign_filter_type', $this->_settings);
-    $defaults['volunteer_general_campaign_filter_list'] = CRM_Utils_Array::value('volunteer_general_campaign_filter_list', $this->_settings);
-    $defaults['volunteer_general_project_settings_help_text'] = CRM_Utils_Array::value('volunteer_general_project_settings_help_text', $this->_settings);
+    $defaults['volunteer_general_campaign_filter_type'] = $this->_settings['volunteer_general_campaign_filter_type'] ?? NULL;
+    $defaults['volunteer_general_campaign_filter_list'] = $this->_settings['volunteer_general_campaign_filter_list'] ?? NULL;
+    $defaults['volunteer_general_project_settings_help_text'] = $this->_settings['volunteer_general_project_settings_help_text'] ?? NULL;
 
     return $defaults;
   }
@@ -272,7 +272,7 @@ class CRM_Volunteer_Form_Settings extends CRM_Core_Form {
 
     foreach ($this->getProjectRelationshipTypes() as $relTypeData) {
       $name = $relTypeData['name'];
-      $selectedMode = CRM_Utils_Array::value("volunteer_project_default_contacts_mode_{$name}", $values);
+      $selectedMode = $values["volunteer_project_default_contacts_mode_{$name}"] ?? NULL;
 
       // skip this check if user did not select a mode; that field is required
       // and there's no sense displaying two messages for the same error
@@ -300,7 +300,7 @@ class CRM_Volunteer_Form_Settings extends CRM_Core_Form {
     $profiles = array();
 
     foreach (CRM_Volunteer_BAO_Project::getProjectProfileAudienceTypes() as $audience) {
-      $profiles[$audience['type']] = CRM_Utils_Array::value('volunteer_project_default_profiles_' . $audience['type'], $values);
+      $profiles[$audience['type']] = $values['volunteer_project_default_profiles_' . $audience['type']] ?? NULL;
     }
 
     civicrm_api3('Setting', 'create', array(
@@ -308,16 +308,16 @@ class CRM_Volunteer_Form_Settings extends CRM_Core_Form {
     ));
 
     civicrm_api3('Setting', 'create', array(
-      "volunteer_project_default_campaign" => CRM_Utils_Array::value('volunteer_project_default_campaign', $values)
+      "volunteer_project_default_campaign" => $values['volunteer_project_default_campaign'] ?? NULL
     ));
     civicrm_api3('Setting', 'create', array(
-      "volunteer_project_default_locblock" => CRM_Utils_Array::value('volunteer_project_default_locblock', $values)
+      "volunteer_project_default_locblock" => $values['volunteer_project_default_locblock'] ?? NULL
     ));
 
-    Civi::settings()->set('volunteer_general_project_settings_help_text', CRM_Utils_Array::value('volunteer_general_project_settings_help_text', $values));
+    Civi::settings()->set('volunteer_general_project_settings_help_text', $values['volunteer_general_project_settings_help_text'] ?? NULL);
 
     civicrm_api3('Setting', 'create', array(
-      "volunteer_project_default_is_active" => CRM_Utils_Array::value('volunteer_project_default_is_active', $values, 0)
+      "volunteer_project_default_is_active" => $values['volunteer_project_default_is_active'] ?? 0
     ));
 
     civicrm_api3('Setting', 'create', array(
@@ -326,10 +326,10 @@ class CRM_Volunteer_Form_Settings extends CRM_Core_Form {
 
     //Whitelist/Blacklist settings
     civicrm_api3('Setting', 'create', array(
-      "volunteer_general_campaign_filter_type" => CRM_Utils_Array::value('volunteer_general_campaign_filter_type', $values)
+      "volunteer_general_campaign_filter_type" => $values['volunteer_general_campaign_filter_type'] ?? NULL
     ));
     civicrm_api3('Setting', 'create', array(
-      "volunteer_general_campaign_filter_list" => CRM_Utils_Array::value('volunteer_general_campaign_filter_list', $values, array())
+      "volunteer_general_campaign_filter_list" => $values['volunteer_general_campaign_filter_list'] ?? []
     ));
 
     CRM_Core_Session::setStatus(ts("Changes Saved", array('domain' => 'org.civicrm.volunteer')), "Saved", "success");
@@ -348,8 +348,8 @@ class CRM_Volunteer_Form_Settings extends CRM_Core_Form {
     if (!$settingName || !$attr) {
       return false;
     }
-    $setting = CRM_Utils_Array::value($settingName, $this->_settingsMetadata, array());
-    return CRM_Utils_Array::value($attr, $setting);
+    $setting = $this->_settingsMetadata[$settingName] ?? [];
+    return $setting[$attr] ?? NULL;
   }
 
   /**

--- a/CRM/Volunteer/Form/VolunteerReport.php
+++ b/CRM/Volunteer/Form/VolunteerReport.php
@@ -379,11 +379,11 @@ class CRM_Volunteer_Form_VolunteerReport extends CRM_Report_Form {
     foreach ($this->_columns as $tableName => $table) {
       if (array_key_exists('fields', $table)) {
         foreach ($table['fields'] as $fieldName => $field) {
-          if (CRM_Utils_Array::value('required', $field) ||
-            CRM_Utils_Array::value($fieldName, $this->_params['fields'])
+          if (!empty($field['required']) ||
+            !empty($this->_params['fields'][$fieldName])
           ) {
             if (isset($this->_params['group_bys']) &&
-              !CRM_Utils_Array::value('activity_type_id', $this->_params['group_bys']) &&
+              empty($this->_params['group_bys']['activity_type_id']) &&
               (in_array($fieldName, array(
                   'contact_assignee', 'assignee_contact_id')) ||
                 in_array($fieldName, array('contact_target', 'target_contact_id'))
@@ -401,9 +401,9 @@ class CRM_Volunteer_Form_VolunteerReport extends CRM_Report_Form {
             }
 
             $alias = "{$tableName}_{$fieldName}";
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = CRM_Utils_Array::value('title', $field);
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['no_display'] = CRM_Utils_Array::value('no_display', $field);
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'] ?? NULL;
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['no_display'] = $field['no_display'] ?? NULL;
             $this->_selectAliases[] = $alias;
           }
         }
@@ -529,27 +529,27 @@ class CRM_Volunteer_Form_VolunteerReport extends CRM_Report_Form {
 
         foreach ($table['filters'] as $fieldName => $field) {
           $clause = NULL;
-          if (CRM_Utils_Array::value('type', $field) & CRM_Utils_Type::T_DATE) {
-            $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
-            $from     = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
-            $to       = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
+          if (($field['type'] ?? NULL) & CRM_Utils_Type::T_DATE) {
+            $relative = $this->_params["{$fieldName}_relative"] ?? NULL;
+            $from     = $this->_params["{$fieldName}_from"] ?? NULL;
+            $to       = $this->_params["{$fieldName}_to"] ?? NULL;
 
             $clause = $this->dateClause($field['name'], $relative, $from, $to, $field['type']);
           }
           else {
-            $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+            $op = $this->_params["{$fieldName}_op"] ?? NULL;
             if ($op) {
               $clause = $this->whereClause($field,
                 $op,
-                CRM_Utils_Array::value("{$fieldName}_value", $this->_params),
-                CRM_Utils_Array::value("{$fieldName}_min", $this->_params),
-                CRM_Utils_Array::value("{$fieldName}_max", $this->_params)
+                $this->_params["{$fieldName}_value"] ?? NULL,
+                $this->_params["{$fieldName}_min"] ?? NULL,
+                $this->_params["{$fieldName}_max"] ?? NULL
               );
             }
           }
 
           if ($field['name'] == 'current_user') {
-            if (CRM_Utils_Array::value("{$fieldName}_value", $this->_params) == 1) {
+            if (!empty($this->_params["{$fieldName}_value"])) {
               // get current user
               $session = CRM_Core_Session::singleton();
               if ($contactID = $session->get('userID')) {
@@ -660,7 +660,7 @@ class CRM_Volunteer_Form_VolunteerReport extends CRM_Report_Form {
     $msgs = array();
     foreach ($updatedFilters as $column) {
       $formKey = $column . '_value';
-      $value = CRM_Utils_Array::value($formKey, $this->_formValues);
+      $value = $this->_formValues[$formKey] ?? NULL;
 
       // bail out if nothing was retrieved or if value matches the new storage format
       if (!$value || preg_match('#^\d+(,\d+)*$#', $value)) {
@@ -786,7 +786,7 @@ class CRM_Volunteer_Form_VolunteerReport extends CRM_Report_Form {
             }
 
             $actionLinks = CRM_Activity_Selector_Activity::actionLinks($row['civicrm_activity_activity_type_id'],
-              CRM_Utils_Array::value('civicrm_activity_source_record_id', $rows[$rowNum]),
+              $rows[$rowNum]['civicrm_activity_source_record_id'] ?? NULL,
               FALSE,
               $rows[$rowNum]['civicrm_activity_id']
             );

--- a/CRM/Volunteer/Page/Router.php
+++ b/CRM/Volunteer/Page/Router.php
@@ -3,7 +3,7 @@
 class CRM_Volunteer_Page_Router extends CRM_Core_Page {
 
   function run($args = NULL) {
-    if (CRM_Utils_Array::value(0, $args) !== 'civicrm' || CRM_Utils_Array::value(1, $args) !== 'volunteer') {
+    if (($args[0] ?? NULL) !== 'civicrm' || ($args[1] ?? NULL) !== 'volunteer') {
       CRM_Core_Error::fatal('Invalid page callback config.');
       return;
     }

--- a/CRM/Volunteer/Upgrader.php
+++ b/CRM/Volunteer/Upgrader.php
@@ -684,7 +684,7 @@ class CRM_Volunteer_Upgrader extends CRM_Extension_Upgrader_Base {
           'return' => 'id',
          )),
       ));
-      if (CRM_Utils_Array::value('is_error', $create)) {
+      if (!empty($create['is_error'])) {
         CRM_Core_Error::debug_var('contactTypeResult', $create, TRUE, TRUE, 'org.civicrm.volunteer');
         throw new CRM_Core_Exception('Failed to register contact type');
       }
@@ -719,7 +719,7 @@ class CRM_Volunteer_Upgrader extends CRM_Extension_Upgrader_Base {
         'name' => self::customContactGroupName,
         'title' => ts('Volunteer Information', array('domain' => 'org.civicrm.volunteer')),
       ));
-      if (CRM_Utils_Array::value('is_error', $create)) {
+      if (!empty($create['is_error'])) {
         CRM_Core_Error::debug_var('customGroupResult', $create, TRUE, TRUE, 'org.civicrm.volunteer');
         throw new CRM_Core_Exception('Failed to register custom group for volunteer subtype');
       }
@@ -746,7 +746,7 @@ class CRM_Volunteer_Upgrader extends CRM_Extension_Upgrader_Base {
       'name' => self::skillLevelOptionGroupName,
       'title' => ts('Skill Level', array('domain' => 'org.civicrm.volunteer')),
     ));
-    $skillLevelOptionGroupId = CRM_Utils_Array::value('id', $skillLevelOptionGroup);
+    $skillLevelOptionGroupId = $skillLevelOptionGroup['id'] ?? NULL;
     // option group ID needs to be fetched if creation attempt was a duplicate
     if (!$skillLevelOptionGroupId) {
       $skillLevelOptionGroupId = civicrm_api3('OptionGroup', 'getvalue', array(
@@ -783,7 +783,7 @@ class CRM_Volunteer_Upgrader extends CRM_Extension_Upgrader_Base {
       'name' => 'camera_skill_level',
       'option_group_id' => $skillLevelOptionGroupId,
     ));
-    $customFieldId = CRM_Utils_Array::value('id', $customField);
+    $customFieldId = $customField['id'] ?? NULL;
     // custom field ID needs to be fetched if creation attempt was a duplicate
     if (!$customFieldId) {
       $customFieldId = civicrm_api3('customField', 'getvalue', array(
@@ -812,13 +812,13 @@ class CRM_Volunteer_Upgrader extends CRM_Extension_Upgrader_Base {
    */
   private function createPossibleDuplicateRecord($entityType, array $params) {
     $apiResult = civicrm_api3($entityType, 'create', $params);
-    if (CRM_Utils_Array::value('is_error', $apiResult)) {
+    if (!empty($apiResult['is_error'])) {
       if ($apiResult['error_code'] == 'already exists') {
         CRM_Core_Session::setStatus(
           ts('CiviVolunteer tried to create a(n) %1 named %2, but it already exists. This may lead to unexpected behavior.',
               array(
                 1 => $entityType,
-                2 => CRM_Utils_Array::value('name', $params),
+                2 => $params['name'] ?? NULL,
                 'domain' => 'org.civicrm.volunteer',
               )),
           ts('Field already exists', array('domain' => 'org.civicrm.volunteer'))
@@ -865,7 +865,7 @@ class CRM_Volunteer_Upgrader extends CRM_Extension_Upgrader_Base {
         );
         $result = civicrm_api('OptionValue', 'create', $params);
 
-        if (CRM_Utils_Array::value('is_error', $result, FALSE)) {
+        if (!empty($result['is_error'])) {
           CRM_Core_Error::debug_var('activityStatusResult', $result, TRUE, TRUE, 'org.civicrm.volunteer');
           throw new CRM_Core_Exception('Failed to register activity status');
         }

--- a/api/v3/VolunteerNeed.php
+++ b/api/v3/VolunteerNeed.php
@@ -81,8 +81,8 @@ function civicrm_api3_volunteer_need_get($params) {
     foreach ($result['values'] as &$need) {
       if (!empty($need['start_time'])) {
         $need['display_time'] = CRM_Volunteer_BAO_Need::getTimes($need['start_time'],
-          CRM_Utils_Array::value('duration', $need),
-          CRM_Utils_Array::value('end_time', $need));
+          $need['duration'] ?? NULL,
+          $need['end_time'] ?? NULL);
       }
       else {
         $need['display_time'] = CRM_Volunteer_BAO_Need::getFlexibleDisplayTime();
@@ -94,7 +94,7 @@ function civicrm_api3_volunteer_need_get($params) {
         );
         $need['role_label'] = $role['label'];
         $need['role_description'] = $role['description'];
-      } elseif (CRM_Utils_Array::value('is_flexible', $need)) {
+      } elseif (!empty($need['is_flexible'])) {
         $need['role_label'] = CRM_Volunteer_BAO_Need::getFlexibleRoleLabel();
         $need['role_description'] = NULL;
       }

--- a/api/v3/VolunteerProject.php
+++ b/api/v3/VolunteerProject.php
@@ -90,7 +90,7 @@ function _civicrm_api3_volunteer_project_create_spec(&$params) {
 function civicrm_api3_volunteer_project_get($params) {
 
   //If we are in an editing context only show projects they can edit.
-  $context = CRM_Utils_Array::value('context', $params);
+  $context = $params['context'] ?? NULL;
   if ($context === 'edit' && !CRM_Volunteer_Permission::check('edit all volunteer projects')) {
 
     if (!isset($params['project_contacts'])) {

--- a/api/v3/VolunteerUtil.php
+++ b/api/v3/VolunteerUtil.php
@@ -147,7 +147,7 @@ function _civicrm_api3_volunteer_util_getsupportingdata_spec(&$params) {
 function civicrm_api3_volunteer_util_getsupportingdata($params) {
   $results = array();
 
-  $controller = CRM_Utils_Array::value('controller', $params);
+  $controller = $params['controller'] ?? NULL;
   if ($controller === 'VolunteerProject') {
     $relTypes = civicrm_api3('OptionValue', 'get', array(
       'option_group_id' => CRM_Volunteer_BAO_ProjectContact::RELATIONSHIP_OPTION_GROUP,
@@ -295,7 +295,7 @@ function civicrm_api3_volunteer_util_getcustomfields($params) {
 
   $optionData = _volunteer_util_groupBy($optionValueAPI['values'], 'option_group_id');
   foreach($customFields as &$field) {
-    $optionGroupId = CRM_Utils_Array::value('option_group_id', $field);
+    $optionGroupId = $field['option_group_id'] ?? NULL;
     if ($optionGroupId) {
       $field['options'] = $optionData[$optionGroupId];
 
@@ -344,13 +344,13 @@ function _volunteer_util_getOptionGroupIds(array $customFields) {
  * Inspired by underscorejs's _.groupBy function.
  *
  * @param array $collection
- * @param type $property
+ * @param string $property
  * @return array
  */
 function _volunteer_util_groupBy(array $collection, $property) {
   $result = array();
   foreach ($collection as $item) {
-    $key = CRM_Utils_Array::value($property, $item);
+    $key = $item[$property] ?? NULL;
     if (!array_key_exists($key, $result)) {
       $result[$key] = array();
     }

--- a/volunteer.php
+++ b/volunteer.php
@@ -127,7 +127,7 @@ function volunteer_civicrm_navigationMenu(&$menu) {
  * appropriate.
  */
 function volunteer_civicrm_tabset($tabsetName, &$tabs, $context) {
-  $eventId = CRM_Utils_Array::value('event_id', $context);
+  $eventId = $context['event_id'] ?? NULL;
 
   if ($tabsetName == 'civicrm/event/manage') {
     if ($eventId) {

--- a/volunteer.slider.php
+++ b/volunteer.slider.php
@@ -30,7 +30,7 @@ function _volunteer_civicrm_buildForm_CRM_Custom_Form_Field($formName, CRM_Core_
  * Handles the "Use Slider Widget?" field added to the custom fields UI
  */
 function _volunteer_civicrm_postProcess_CRM_Custom_Form_Field($formName, &$form) {
-  $is_slider_widget = CRM_Utils_Array::value('is_slider_widget', $form->_submitValues);
+  $is_slider_widget = $form->_submitValues['is_slider_widget'] ?? NULL;
   $custom_field_id = $form->getVar('_id');
 
   $verb = $is_slider_widget ? CRM_Core_Action::ADD : CRM_Core_Action::DELETE;
@@ -65,7 +65,7 @@ function _volunteer_addSliderWidget(CRM_Core_Form &$form) {
     $widgetized_fields = array_intersect($form_element_names, $db_widgetized_fields);
 
     foreach ($widgetized_fields as $field_name) {
-      $css_classes = CRM_Utils_Array::value('class', $form->getElement($field_name)->_attributes);
+      $css_classes = $form->getElement($field_name)->_attributes['class'] ?? '';
       $form->getElement($field_name)->_attributes['class'] = trim($css_classes . ' volunteer_slider');
     }
 
@@ -101,12 +101,12 @@ function _volunteer_get_slider_fields() {
  *              and CRM_Core_Action::DELETE arrays, it will be removed.
  */
 function _volunteer_update_slider_fields(array $params) {
-  $add = CRM_Utils_Array::value(CRM_Core_Action::ADD, $params, array());
+  $add = $params[CRM_Core_Action::ADD] ?? [];
   if (!is_array($add)) {
     $add = array($add);
   }
 
-  $remove = CRM_Utils_Array::value(CRM_Core_Action::DELETE, $params, array());
+  $remove = $params[CRM_Core_Action::DELETE] ?? [];
   if (!is_array($remove)) {
     $remove = array($remove);
   }


### PR DESCRIPTION
Replaces deprecated function with equivalent null-coalescing operator. Behavior should be the same before/after.