### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Volunteer/BAO/Project.php
+++ b/CRM/Volunteer/BAO/Project.php
@@ -710,7 +710,7 @@ class CRM_Volunteer_BAO_Project extends CRM_Volunteer_DAO_Project {
    * to the angular front-end
    *
    * @return array
-   * @throws CiviCRM_API3_Exception
+   * @throws CRM_Core_Exception
    */
   public static function composeDefaultSettingsArray() {
     $defaults = array();

--- a/CRM/Volunteer/Upgrader.php
+++ b/CRM/Volunteer/Upgrader.php
@@ -144,7 +144,7 @@ class CRM_Volunteer_Upgrader extends CRM_Extension_Upgrader_Base {
       ));
       $optionGroupId = $optionGroup['id'];
 
-      // VOL-288: Prevent caching-related CiviCRM_API3_Exception: "N is not a valid option for field option_group_id"
+      // VOL-288: Prevent caching-related CRM_Core_Exception: "N is not a valid option for field option_group_id"
       CRM_Core_Invoke::rebuildMenuAndCaches();
     } catch (Exception $e) {
       // if an exception is thrown, most likely the option group already exists,


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.