### PR TITLE
Add bulk shift creation for volunteer needs

### DIFF
--- a/api/v3/VolunteerNeed.php
+++ b/api/v3/VolunteerNeed.php
@@ -189,3 +189,157 @@ function civicrm_api3_volunteer_need_delete($params) {
   return _civicrm_api3_basic_delete('CRM_Volunteer_BAO_Need', $params);
 }
 
+/**
+ * Metadata for the createbulk action.
+ *
+ * @param array $params
+ */
+function _civicrm_api3_volunteer_need_createbulk_spec(&$params) {
+  $params['project_id'] = array(
+    'title' => 'Project ID',
+    'description' => 'Project in which the shifts will be created.',
+    'type' => CRM_Utils_Type::T_INT,
+    'api.required' => 1,
+  );
+  $params['role_id'] = array(
+    'title' => 'Role',
+    'description' => 'Volunteer role ID to assign to each created shift.',
+    'type' => CRM_Utils_Type::T_INT,
+    'api.required' => 1,
+  );
+  $params['start_date'] = array(
+    'title' => 'Start Date',
+    'description' => 'Date (YYYY-MM-DD) of the first day on which shifts are generated.',
+    'type' => CRM_Utils_Type::T_DATE,
+    'api.required' => 1,
+  );
+  $params['start_time'] = array(
+    'title' => 'Start Time',
+    'description' => 'Time of day (HH:MM or HH:MM:SS) at which the first shift of each day starts.',
+    'type' => CRM_Utils_Type::T_STRING,
+    'api.required' => 1,
+  );
+  $params['duration'] = array(
+    'title' => 'Duration (minutes)',
+    'description' => 'Length of each shift in minutes.',
+    'type' => CRM_Utils_Type::T_INT,
+    'api.required' => 1,
+  );
+  $params['shifts_per_day'] = array(
+    'title' => 'Shifts Per Day',
+    'description' => 'Number of consecutive shifts to generate on each day.',
+    'type' => CRM_Utils_Type::T_INT,
+    'api.default' => 1,
+  );
+  $params['day_count'] = array(
+    'title' => 'Day Count',
+    'description' => 'Number of consecutive days on which shifts should be generated.',
+    'type' => CRM_Utils_Type::T_INT,
+    'api.default' => 1,
+  );
+  $params['gap_minutes'] = array(
+    'title' => 'Gap Between Shifts (minutes)',
+    'description' => 'Optional gap in minutes between the end of one shift and the start of the next on the same day.',
+    'type' => CRM_Utils_Type::T_INT,
+    'api.default' => 0,
+  );
+  $params['quantity'] = array(
+    'title' => 'Volunteers Needed Per Shift',
+    'description' => 'Number of volunteers needed for each generated shift.',
+    'type' => CRM_Utils_Type::T_INT,
+    'api.default' => 1,
+  );
+  $params['is_active'] = array(
+    'title' => 'Is Active',
+    'type' => CRM_Utils_Type::T_BOOLEAN,
+    'api.default' => 1,
+  );
+  $params['visibility_id'] = array(
+    'title' => 'Visibility',
+    'type' => CRM_Utils_Type::T_INT,
+  );
+}
+
+/**
+ * Create a set of Volunteer Needs from a simple repeating pattern.
+ *
+ * Generates `shifts_per_day` shifts of `duration` minutes starting at
+ * `start_time` on each of `day_count` consecutive days, beginning on
+ * `start_date`.
+ *
+ * @param array $params
+ * @return array
+ */
+function civicrm_api3_volunteer_need_createbulk($params) {
+  $shiftsPerDay = max(1, (int) $params['shifts_per_day']);
+  $dayCount = max(1, (int) $params['day_count']);
+  $duration = (int) $params['duration'];
+  $gapMinutes = (int) CRM_Utils_Array::value('gap_minutes', $params, 0);
+
+  if ($duration < 1) {
+    throw new API_Exception('Duration must be at least 1 minute.');
+  }
+
+  // Normalize start time to HH:MM:SS.
+  $startTime = trim($params['start_time']);
+  if (preg_match('/^\d{1,2}:\d{2}$/', $startTime)) {
+    $startTime .= ':00';
+  }
+  if (!preg_match('/^\d{1,2}:\d{2}:\d{2}$/', $startTime)) {
+    throw new API_Exception('start_time must be formatted as HH:MM or HH:MM:SS.');
+  }
+
+  $startDate = trim($params['start_date']);
+  // APIv3 may deliver T_DATE values as YYYYMMDDHHMMSS; normalize to YYYY-MM-DD.
+  if (preg_match('/^(\d{4})(\d{2})(\d{2})/', $startDate, $m)) {
+    $startDate = "{$m[1]}-{$m[2]}-{$m[3]}";
+  }
+
+  try {
+    $firstShift = new DateTime($startDate . ' ' . $startTime);
+  }
+  catch (Exception $e) {
+    throw new API_Exception('Could not parse start_date/start_time: ' . $e->getMessage());
+  }
+
+  $baseParams = array(
+    'project_id' => $params['project_id'],
+    'role_id' => $params['role_id'],
+    'duration' => $duration,
+    'quantity' => (int) CRM_Utils_Array::value('quantity', $params, 1),
+    'is_active' => !empty($params['is_active']) ? 1 : 0,
+    'is_flexible' => 0,
+  );
+  if (isset($params['visibility_id'])) {
+    $baseParams['visibility_id'] = $params['visibility_id'];
+  }
+  if (!empty($params['check_permissions'])) {
+    $baseParams['check_permissions'] = 1;
+  }
+
+  $created = array();
+  $stepMinutes = $duration + max(0, $gapMinutes);
+
+  for ($day = 0; $day < $dayCount; $day++) {
+    for ($slot = 0; $slot < $shiftsPerDay; $slot++) {
+      $shiftStart = clone $firstShift;
+      if ($day > 0) {
+        $shiftStart->add(new DateInterval('P' . $day . 'D'));
+      }
+      if ($slot > 0) {
+        $shiftStart->add(new DateInterval('PT' . ($slot * $stepMinutes) . 'M'));
+      }
+
+      $needParams = $baseParams;
+      $needParams['start_time'] = $shiftStart->format('Y-m-d H:i:s');
+
+      $result = civicrm_api3('VolunteerNeed', 'create', $needParams);
+      if (!empty($result['id'])) {
+        $created[$result['id']] = CRM_Utils_Array::first($result['values']);
+      }
+    }
+  }
+
+  return civicrm_api3_create_success($created, $params, 'VolunteerNeed', 'createbulk');
+}
+

--- a/css/volunteer_app.css
+++ b/css/volunteer_app.css
@@ -199,6 +199,65 @@
   min-width: 12em;
 }
 
+/* Define dialog: bulk link lives inside .ui-dialog-buttonset (prepended before
+   Done) so the native button bar layout stays intact. */
+#crm-volunteer-dialog ~ .ui-dialog-buttonpane {
+  text-align: right;
+}
+#crm-volunteer-dialog ~ .ui-dialog-buttonpane .ui-dialog-buttonset {
+  float: none;
+  display: inline-flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.65em;
+  max-width: 100%;
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0.2em 0.35em;
+}
+#crm-volunteer-dialog ~ .ui-dialog-buttonpane .crm-vol-define-bulk-footer-wrap {
+  float: none;
+  margin: 0;
+  padding: 0;
+  flex: 0 1 auto;
+  min-width: 0;
+}
+#crm-volunteer-dialog ~ .ui-dialog-buttonpane .crm-vol-define-bulk-footer-wrap a.button {
+  margin: 0;
+  max-width: 100%;
+}
+#crm-volunteer-dialog ~ .ui-dialog-buttonpane .ui-dialog-buttonset > .ui-button {
+  flex: 0 0 auto;
+}
+
 .crm-vol-renderutil-select {
   white-space: nowrap;
+}
+
+/* Tight gap between field row and hint row */
+.crm-vol-define-bulk-form .crm-vol-define-bulk-hint-row td {
+  padding-top: 0;
+  padding-bottom: 0.35em;
+  vertical-align: top;
+}
+.crm-vol-define-bulk-form .crm-vol-define-bulk-hint-row td.label {
+  padding-top: 0;
+  padding-bottom: 0;
+  border: none;
+  line-height: 0;
+  height: 0;
+  overflow: hidden;
+}
+.crm-vol-define-bulk-form .crm-vol-define-bulk-hint {
+  display: block;
+  margin-top: -0.35em;
+  font-size: 0.85em;
+  font-style: italic;
+  color: #555;
+  line-height: 1.35;
+}
+.crm-vol-define-bulk-form tr:has(+ tr.crm-vol-define-bulk-hint-row) td {
+  padding-bottom: 0.2em;
 }

--- a/js/backbone/apps/define/define_controller.js
+++ b/js/backbone/apps/define/define_controller.js
@@ -29,16 +29,18 @@ CRM.volunteerApp.module('Define', function(Define, volunteerApp, Backbone, Mario
           Define.needRegistry.clean.push(item.id);
         });
 
+        var flexibleNeedModel = new CRM.volunteerApp.Entities.NeedModel(_.findWhere(arrData, {is_flexible: '1'}));
         Define.collectionView = new Define.needsCompositeView({
-          'collection': collectionData
+          collection: collectionData,
+          flexibleModel: flexibleNeedModel
         });
         layout.scheduledNeeds.show(Define.collectionView);
-
-        var flexibleNeedModel = new CRM.volunteerApp.Entities.NeedModel(_.findWhere(arrData, {is_flexible: '1'}));
-        var flexibleItemView = new Define.flexibleNeedItemView(flexibleNeedModel);
-        flexibleItemView.model = flexibleNeedModel;
-        layout.flexibleNeeds.show(flexibleItemView);
+        Define.attachBulkButtonToDialog();
       });
+  });
+
+  Define.on('stop', function() {
+    Define.detachBulkButtonFromDialog();
   });
 
 });

--- a/js/backbone/apps/define/define_views.js
+++ b/js/backbone/apps/define/define_views.js
@@ -7,8 +7,7 @@
     Define.layout = Marionette.Layout.extend({
       template: "#crm-vol-define-layout-tpl",
       regions: {
-        scheduledNeeds: "#crm-vol-define-scheduled-needs-region",
-        flexibleNeeds: "#crm-vol-define-flexible-needs-region"
+        scheduledNeeds: "#crm-vol-define-scheduled-needs-region"
       }
     });
 
@@ -267,9 +266,12 @@
       tagName: 'tr'
     }));
 
-    Define.flexibleNeedItemView = Marionette.ItemView.extend(_.extend(itemViewSettings, {
+    Define.flexibleNeedItemView = Marionette.ItemView.extend(_.extend({}, itemViewSettings, {
       template: '#crm-vol-define-flexible-need-tpl',
-      tagName: 'div'
+      tagName: 'tr',
+      attributes: function() {
+        return { class: 'crm-vol-define-flexible-need-row' };
+      }
     }));
 
     Define.needsCompositeView = Marionette.CompositeView.extend({
@@ -277,6 +279,10 @@
       template: "#crm-vol-define-table-tpl",
       itemView: Define.scheduledNeedItemView,
       itemViewContainer: '#crm-vol-define-needs-table > tbody',
+
+      initialize: function(options) {
+        this.flexibleModel = options.flexibleModel;
+      },
 
       events: {
         'change #crm-vol-define-add-need': 'addNewNeed'
@@ -308,9 +314,209 @@
       },
 
       onRender: function() {
-        this.$('#crm-vol-define-needs-table > tbody').append($('#crm-vol-define-add-row-tpl').html());
-        this.$('#crm-vol-define-add-need').crmSelect2();
+        if (!this.$('#crm-vol-define-add-row').length) {
+          this.$('#crm-vol-define-needs-table > tbody').append($('#crm-vol-define-add-row-tpl').html());
+          this.$('#crm-vol-define-add-need').crmSelect2();
+        }
+        if (this.flexibleModel) {
+          if (this.flexibleItemView) {
+            this.flexibleItemView.close();
+            this.flexibleItemView = null;
+          }
+          this.flexibleItemView = new Define.flexibleNeedItemView({
+            model: this.flexibleModel
+          });
+          this.flexibleItemView.render();
+          this.$('#crm-vol-define-add-row').before(this.flexibleItemView.el);
+        }
+      },
+
+      onClose: function() {
+        if (this.flexibleItemView) {
+          this.flexibleItemView.close();
+          this.flexibleItemView = null;
+        }
       }
     });
+
+    /**
+     * Shows a modal form for creating many shifts from a simple repeating
+     * pattern. When the form is submitted, VolunteerNeed.createbulk runs on
+     * the server and the just-created shifts are appended to the existing
+     * needs list, where each one can be individually modified or deleted.
+     */
+    Define.showBulkCreateDialog = function(collection) {
+      var $form = $('<div class="crm-vol-define-bulk-dialog"></div>')
+        .html($('#crm-vol-define-bulk-form-tpl').html());
+
+      // Default start date = today; default start time = 09:00.
+      var today = new Date();
+      $form.find('[name=start_date]').addClass('dateplugin').datepicker().datepicker('setDate', today);
+      $form.find('[name=start_time]').addClass('timeplugin').timeEntry({
+        show24Hours: CRM.config.timeInputFormat == 2
+      }).timeEntry('setTime', '09:00:00');
+      $form.find('select.crm-select2').crmSelect2();
+
+      var renderPreview = function() {
+        var parsed = parseBulkForm($form);
+        var $preview = $form.find('.crm-vol-bulk-preview').empty();
+        if (!parsed.ok) {
+          $preview.append($('<div class="status messages">').text(parsed.error));
+          return;
+        }
+        var total = parsed.params.shifts_per_day * parsed.params.day_count;
+        $preview.append($('<div class="status messages">').text(
+          ts('%1 shifts will be created (%2 per day x %3 days, %4 minutes each, starting %5 at %6).', {
+            1: total,
+            2: parsed.params.shifts_per_day,
+            3: parsed.params.day_count,
+            4: parsed.params.duration,
+            5: parsed.params.start_date,
+            6: parsed.params.start_time
+          })
+        ));
+      };
+
+      $form.on('change blur input', ':input', renderPreview);
+      setTimeout(renderPreview, 0);
+
+      var dialog = CRM.confirm({
+        title: ts('Add shifts in bulk'),
+        message: $form,
+        options: {
+          no: ts('Cancel'),
+          yes: ts('Create shifts')
+        },
+        width: '600px'
+      });
+
+      dialog.on('crmConfirm:yes', function() {
+        var parsed = parseBulkForm($form);
+        if (!parsed.ok) {
+          CRM.alert(parsed.error, ts('Invalid input'), 'error');
+          return false;
+        }
+
+        var $tableBlockTarget = $('#crm-vol-define-needs-table');
+        $tableBlockTarget.block();
+
+        CRM.api3('VolunteerNeed', 'createbulk', parsed.params, true)
+          .done(function(result) {
+            $tableBlockTarget.unblock();
+            if (result.is_error) {
+              return;
+            }
+            var createdIds = _.keys(result.values || {});
+            if (!createdIds.length) {
+              return;
+            }
+            // Reload the needs list so new shifts show up with proper
+            // formatted dates/times and the usual per-row edit controls.
+            volunteerApp.Entities.getNeeds({'api.volunteer_assignment.getcount': {}})
+              .done(function(arrData) {
+                var scheduled = volunteerApp.Entities.Needs.getScheduled(arrData);
+                collection.reset(scheduled.models);
+                _.each(createdIds, function(id) {
+                  Define.registerNeedChange('created', parseInt(id, 10));
+                });
+                CRM.alert(
+                  ts('%1 shifts have been created. You can now modify or delete each one individually.', {1: createdIds.length}),
+                  '',
+                  'success'
+                );
+              });
+          })
+          .fail(function() {
+            $tableBlockTarget.unblock();
+          });
+      });
+    };
+
+    /**
+     * Places "Add shifts in bulk" inside .ui-dialog-buttonset, before Done.
+     */
+    Define.attachBulkButtonToDialog = function() {
+      var $pane = CRM.$('#crm-volunteer-dialog').closest('.ui-dialog').find('.ui-dialog-buttonpane').first();
+      var $buttonset = $pane.find('.ui-dialog-buttonset').first();
+      if (!$pane.length || !$buttonset.length || !Define.collectionView || !Define.collectionView.collection) {
+        return;
+      }
+      $pane.find('.crm-vol-define-bulk-footer-wrap').remove();
+      var $wrap = CRM.$('<div class="crm-vol-define-bulk-footer-wrap"></div>');
+      var $btn = CRM.$('<a href="#" id="crm-vol-define-add-bulk" class="button crm-hover-button"></a>');
+      $btn.html('<span><div class="icon ui-icon-calendar"></div>' + ts('Add shifts in bulk') + '</span>');
+      $wrap.append($btn);
+      $buttonset.prepend($wrap);
+      $btn.on('click', function(e) {
+        e.preventDefault();
+        Define.showBulkCreateDialog(Define.collectionView.collection);
+      });
+    };
+
+    Define.detachBulkButtonFromDialog = function() {
+      CRM.$('#crm-volunteer-dialog').closest('.ui-dialog').find('.crm-vol-define-bulk-footer-wrap').remove();
+    };
+
+    /**
+     * Reads values from the bulk creation form and validates them.
+     * Returns {ok: true, params: {...}} on success, or
+     * {ok: false, error: '...'} on failure.
+     */
+    function parseBulkForm($form) {
+      var roleId = $form.find('[name=role_id]').val();
+      var shiftsPerDay = parseInt($form.find('[name=shifts_per_day]').val(), 10);
+      var durationHours = parseFloat($form.find('[name=duration_hours]').val());
+      var gapMinutes = parseInt($form.find('[name=gap_minutes]').val(), 10) || 0;
+      var dayCount = parseInt($form.find('[name=day_count]').val(), 10);
+      var quantity = parseInt($form.find('[name=quantity]').val(), 10);
+      var isPublic = $form.find('[name=visibility_id]').is(':checked');
+      var isActive = $form.find('[name=is_active]').is(':checked');
+
+      var startDateObj = $form.find('[name=start_date]').datepicker('getDate');
+      var startTimeObj = $form.find('[name=start_time]').timeEntry('getTime');
+
+      if (!roleId) {
+        return {ok: false, error: ts('Please select a role.')};
+      }
+      if (!shiftsPerDay || shiftsPerDay < 1) {
+        return {ok: false, error: ts('Shifts per day must be at least 1.')};
+      }
+      if (!dayCount || dayCount < 1) {
+        return {ok: false, error: ts('Number of days must be at least 1.')};
+      }
+      if (!(durationHours > 0)) {
+        return {ok: false, error: ts('Duration must be greater than zero.')};
+      }
+      if (!startDateObj) {
+        return {ok: false, error: ts('Please choose a start date.')};
+      }
+      if (!startTimeObj) {
+        return {ok: false, error: ts('Please choose a start time.')};
+      }
+
+      function pad(n) { n = String(n); return n.length === 1 ? '0' + n : n; }
+      var startDate = startDateObj.getFullYear() + '-'
+        + pad(startDateObj.getMonth() + 1) + '-'
+        + pad(startDateObj.getDate());
+      var startTime = startTimeObj.toTimeString().split(' ')[0];
+      var duration = Math.round(durationHours * 60);
+
+      var params = {
+        project_id: volunteerApp.project_id,
+        role_id: roleId,
+        shifts_per_day: shiftsPerDay,
+        day_count: dayCount,
+        duration: duration,
+        gap_minutes: gapMinutes,
+        start_date: startDate,
+        start_time: startTime,
+        quantity: quantity || 1,
+        is_active: isActive ? 1 : 0,
+        visibility_id: isPublic
+          ? CRM.pseudoConstant.volunteer_need_visibility.public
+          : CRM.pseudoConstant.volunteer_need_visibility.admin
+      };
+      return {ok: true, params: params};
+    }
   });
 }(CRM.ts('org.civicrm.volunteer')));

--- a/templates/CRM/Volunteer/Page/Backbone/Define.tpl
+++ b/templates/CRM/Volunteer/Page/Backbone/Define.tpl
@@ -36,7 +36,6 @@
     <div id="crm-vol-define-scheduled-needs-region">
       <div class="crm-loading-element">{ts domain='org.civicrm.volunteer'}Loading{/ts}...</div>
     </div>
-    <div id="crm-vol-define-flexible-needs-region"></div>
   </form>
 </script>
 
@@ -122,8 +121,10 @@
 </script>
 
 <script type="text/template" id="crm-vol-define-flexible-need-tpl">
-  <input type="checkbox" name="visibility_id" id="crm-vol-visibility-id" value="<%= visibilityValue %>">
-  <label for="crm-vol-visibility-id">Allow users to sign up without specifying a shift.</label>
+  <td colspan="8">
+    <input type="checkbox" name="visibility_id" id="crm-vol-visibility-id" value="<%= visibilityValue %>">
+    <label for="crm-vol-visibility-id">Allow users to sign up without specifying a shift.</label>
+  </td>
 </script>
 
 <script type="text/template" id="crm-vol-define-add-row-tpl">
@@ -138,5 +139,75 @@
       </select>
     </td>
   </tr>
+</script>
+
+<script type="text/template" id="crm-vol-define-bulk-form-tpl">
+  <form class="crm-block crm-form-block crm-vol-define-bulk-form">
+    <p class="description">
+      {ts domain='org.civicrm.volunteer'}Generate a set of shifts by describing a simple repeating pattern. Each generated shift will appear in the list below, where you can individually modify or delete them.{/ts}
+    </p>
+    <table class="form-layout-compressed">
+      <tr>
+        <td class="label"><label for="crm-vol-bulk-role">{ts domain='org.civicrm.volunteer'}Role{/ts}</label></td>
+        <td>
+          <select id="crm-vol-bulk-role" name="role_id" class="crm-form-select crm-select2 required">
+            {crmAPI var='bulkRoles' entity='VolunteerNeed' action='getoptions' field='role_id' sequential=0}
+            {foreach from=$bulkRoles.values item=roleLabel key=roleId}
+              <option value="{$roleId}">{$roleLabel}</option>
+            {/foreach}
+          </select>
+        </td>
+      </tr>
+      <tr>
+        <td class="label"><label for="crm-vol-bulk-shifts-per-day">{ts domain='org.civicrm.volunteer'}Shifts per day{/ts}</label></td>
+        <td><input type="number" id="crm-vol-bulk-shifts-per-day" name="shifts_per_day" class="crm-form-text required" value="1" min="1" size="4"></td>
+      </tr>
+      <tr>
+        <td class="label"><label for="crm-vol-bulk-duration">{ts domain='org.civicrm.volunteer'}Duration (hours){/ts}</label></td>
+        <td>
+          <input type="number" id="crm-vol-bulk-duration" name="duration_hours" class="crm-form-text required" value="1" min="0" step="0.25" size="6">
+        </td>
+      </tr>
+      <tr class="crm-vol-define-bulk-hint-row">
+        <td class="label"></td>
+        <td><span class="crm-vol-define-bulk-hint">{ts domain='org.civicrm.volunteer'}Length of each shift.{/ts}</span></td>
+      </tr>
+      <tr>
+        <td class="label"><label for="crm-vol-bulk-start-time">{ts domain='org.civicrm.volunteer'}Start time{/ts}</label></td>
+        <td>
+          <input type="text" id="crm-vol-bulk-start-time" name="start_time" class="crm-form-text required" size="10">
+        </td>
+      </tr>
+      <tr class="crm-vol-define-bulk-hint-row">
+        <td class="label"></td>
+        <td><span class="crm-vol-define-bulk-hint">{ts domain='org.civicrm.volunteer'}Start time for the first shift of each day.{/ts}</span></td>
+      </tr>
+      <tr>
+        <td class="label"><label for="crm-vol-bulk-gap">{ts domain='org.civicrm.volunteer'}Gap between shifts (minutes){/ts}</label></td>
+        <td><input type="number" id="crm-vol-bulk-gap" name="gap_minutes" class="crm-form-text" value="0" min="0" size="4"></td>
+      </tr>
+      <tr>
+        <td class="label"><label for="crm-vol-bulk-day-count">{ts domain='org.civicrm.volunteer'}Number of days{/ts}</label></td>
+        <td><input type="number" id="crm-vol-bulk-day-count" name="day_count" class="crm-form-text required" value="1" min="1" size="4"></td>
+      </tr>
+      <tr>
+        <td class="label"><label for="crm-vol-bulk-start-date">{ts domain='org.civicrm.volunteer'}Start date{/ts}</label></td>
+        <td><input type="text" id="crm-vol-bulk-start-date" name="start_date" class="crm-form-text required" size="20"></td>
+      </tr>
+      <tr>
+        <td class="label"><label for="crm-vol-bulk-quantity">{ts domain='org.civicrm.volunteer'}Volunteers needed per shift{/ts}</label></td>
+        <td><input type="number" id="crm-vol-bulk-quantity" name="quantity" class="crm-form-text required" value="1" min="1" size="4"></td>
+      </tr>
+      <tr>
+        <td class="label"><label for="crm-vol-bulk-public">{ts domain='org.civicrm.volunteer'}Public?{/ts}</label></td>
+        <td><input type="checkbox" id="crm-vol-bulk-public" name="visibility_id" checked></td>
+      </tr>
+      <tr>
+        <td class="label"><label for="crm-vol-bulk-active">{ts domain='org.civicrm.volunteer'}Enabled?{/ts}</label></td>
+        <td><input type="checkbox" id="crm-vol-bulk-active" name="is_active" checked></td>
+      </tr>
+    </table>
+    <div class="crm-vol-bulk-preview" style="margin-top: 1em;"></div>
+  </form>
 </script>
 {/strip}


### PR DESCRIPTION
Introduces a VolunteerNeed.createbulk APIv3 action that generates a set of shifts from a simple repeating pattern (X shifts of Y minutes starting at HH:MM for Z days beginning on a given date, with an optional inter-shift gap).

Adds an "Add shifts in bulk" button to the Define dialog that opens a modal form collecting the pattern, shows a live preview of how many shifts will be produced, and reloads the needs list on success so each generated shift can be individually modified or deleted through the existing per-row controls.

<img width="1119" height="854" alt="image" src="https://github.com/user-attachments/assets/768a53cc-a6d0-48dc-a10b-844c8ef2925e" />
