### PR TITLE
Allow volunteers to self-manage their own shift signups

### DIFF
--- a/ang/volunteer.css
+++ b/ang/volunteer.css
@@ -151,3 +151,28 @@ span.crm-button-text {
 #crm-vol-form-textarea-wrapper {
   clear: left;
 }
+
+.crm-vol-my-shifts-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1em;
+}
+.crm-vol-my-shifts-table th,
+.crm-vol-my-shifts-table td {
+  padding: 6px 8px;
+  vertical-align: top;
+  border-bottom: 1px solid #eaeaea;
+}
+.crm-vol-my-shifts-table th {
+  text-align: left;
+  background: #f5f5f5;
+}
+.crm-vol-my-shift-actions {
+  white-space: nowrap;
+}
+.crm-vol-my-shift-actions .button {
+  margin-right: 4px;
+}
+.crm-vol-my-shift-cancel {
+  color: #b00;
+}

--- a/ang/volunteer/MyShifts.html
+++ b/ang/volunteer/MyShifts.html
@@ -1,0 +1,68 @@
+<div class="crm-container crm-vol-my-shifts">
+
+  <div class="help">
+    <p>
+      {{:: ts('Below are the volunteer shifts you have signed up for. You can edit the time you plan to spend, log hours you have already worked, or cancel a shift.') }}
+    </p>
+  </div>
+
+  <div class="crm-vol-buttons">
+    <button type="button" class="button" ng-click="findMore()">
+      <span><div class="icon ui-icon-search"></div>{{:: ts('Find More Opportunities') }}</span>
+    </button>
+  </div>
+
+  <div ng-show="!contactId" class="messages status">
+    <p>{{:: ts('Please log in to view and manage your shifts.') }}</p>
+  </div>
+
+  <div ng-show="contactId && !hasShifts()" class="messages status">
+    <p>{{:: ts('You are not currently signed up for any volunteer shifts.') }}</p>
+  </div>
+
+  <table ng-show="contactId && hasShifts()" class="crm-vol-my-shifts-table">
+    <thead>
+      <tr>
+        <th>{{:: ts('When') }}</th>
+        <th>{{:: ts('Role / Subject') }}</th>
+        <th>{{:: ts('Scheduled (mins)') }}</th>
+        <th>{{:: ts('Completed (mins)') }}</th>
+        <th>{{:: ts('Notes') }}</th>
+        <th>{{:: ts('Actions') }}</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr ng-repeat="shift in shifts track by shift.id" class="crm-vol-my-shift-row">
+        <td>{{ formatDate(shift) }}</td>
+        <td>{{ shift.subject }}</td>
+        <td>
+          <span ng-hide="isEditing(shift)">{{ shift.time_scheduled_minutes }}</span>
+          <input ng-show="isEditing(shift)" type="number" min="0" ng-model="shift.time_scheduled_minutes" class="crm-form-text" />
+        </td>
+        <td>
+          <span ng-hide="isEditing(shift)">{{ shift.time_completed_minutes }}</span>
+          <input ng-show="isEditing(shift)" type="number" min="0" ng-model="shift.time_completed_minutes" class="crm-form-text" />
+        </td>
+        <td>
+          <span ng-hide="isEditing(shift)" ng-bind-html="shift.details"></span>
+          <textarea ng-show="isEditing(shift)" ng-model="shift.details" class="crm-form-textarea"></textarea>
+        </td>
+        <td class="crm-vol-my-shift-actions">
+          <button ng-hide="isEditing(shift)" type="button" class="button" ng-click="editShift(shift)">
+            {{:: ts('Edit') }}
+          </button>
+          <button ng-hide="isEditing(shift)" type="button" class="button crm-vol-my-shift-cancel" ng-click="cancelShift(shift)">
+            {{:: ts('Cancel Shift') }}
+          </button>
+          <button ng-show="isEditing(shift)" type="button" class="button" ng-click="saveShift(shift)">
+            {{:: ts('Save') }}
+          </button>
+          <button ng-show="isEditing(shift)" type="button" class="button" ng-click="cancelEdit(shift)">
+            {{:: ts('Discard') }}
+          </button>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
+</div>

--- a/ang/volunteer/MyShifts.js
+++ b/ang/volunteer/MyShifts.js
@@ -1,0 +1,118 @@
+(function (angular, $, _) {
+
+  angular.module('volunteer').config(function ($routeProvider) {
+    $routeProvider.when('/volunteer/my-shifts', {
+      controller: 'VolunteerMyShifts',
+      templateUrl: '~/volunteer/MyShifts.html',
+      resolve: {
+        contactId: function () {
+          var cid = (CRM.config && CRM.config.cid) || CRM.userContactID || null;
+          if (!cid) {
+            CRM.alert(
+              ts('You must be logged in to manage your volunteer shifts.', { domain: 'org.civicrm.volunteer' }),
+              ts('Login required'),
+              'error'
+            );
+          }
+          return cid;
+        },
+        assignments: function (crmApi, contactId) {
+          if (!contactId) {
+            return { values: {} };
+          }
+          return crmApi('VolunteerAssignment', 'get', {
+            assignee_contact_id: contactId,
+            options: { limit: 0 }
+          });
+        }
+      }
+    });
+  });
+
+  angular.module('volunteer').controller('VolunteerMyShifts', function (
+    $scope, $window, crmApi, crmStatus, contactId, assignments
+  ) {
+    var ts = $scope.ts = CRM.ts('org.civicrm.volunteer');
+
+    $scope.contactId = contactId;
+    $scope.shifts = _.values((assignments && assignments.values) || {});
+    $scope.editing = {};
+
+    $scope.hasShifts = function () {
+      return $scope.shifts && $scope.shifts.length > 0;
+    };
+
+    $scope.formatDate = function (shift) {
+      var when = shift.start_time || shift.activity_date_time;
+      if (!when) {
+        return ts('Flexible');
+      }
+      // Render using the user's locale.
+      var d = new Date(when.replace(' ', 'T'));
+      if (isNaN(d.getTime())) {
+        return when;
+      }
+      return d.toLocaleString();
+    };
+
+    $scope.editShift = function (shift) {
+      // Snapshot fields the volunteer is allowed to change so we can revert.
+      $scope.editing[shift.id] = {
+        time_scheduled_minutes: shift.time_scheduled_minutes,
+        time_completed_minutes: shift.time_completed_minutes,
+        details: shift.details
+      };
+    };
+
+    $scope.cancelEdit = function (shift) {
+      var snapshot = $scope.editing[shift.id];
+      if (snapshot) {
+        shift.time_scheduled_minutes = snapshot.time_scheduled_minutes;
+        shift.time_completed_minutes = snapshot.time_completed_minutes;
+        shift.details = snapshot.details;
+      }
+      delete $scope.editing[shift.id];
+    };
+
+    $scope.isEditing = function (shift) {
+      return $scope.editing.hasOwnProperty(shift.id);
+    };
+
+    $scope.saveShift = function (shift) {
+      var payload = {
+        id: shift.id,
+        time_scheduled_minutes: shift.time_scheduled_minutes,
+        time_completed_minutes: shift.time_completed_minutes,
+        details: shift.details
+      };
+      return crmStatus(
+        { start: ts('Saving...'), success: ts('Shift updated') },
+        crmApi('VolunteerAssignment', 'create', payload).then(function () {
+          delete $scope.editing[shift.id];
+        })
+      );
+    };
+
+    $scope.cancelShift = function (shift) {
+      CRM.confirm({
+        title: ts('Cancel this shift?'),
+        message: ts('Are you sure you want to remove your sign-up for this shift? This cannot be undone.')
+      }).on('crmConfirm:yes', function () {
+        crmStatus(
+          { start: ts('Cancelling...'), success: ts('Shift cancelled') },
+          crmApi('VolunteerAssignment', 'delete', { id: shift.id }).then(function () {
+            $scope.shifts = _.filter($scope.shifts, function (s) {
+              return s.id !== shift.id;
+            });
+            $scope.$apply();
+          })
+        );
+      });
+    };
+
+    $scope.findMore = function () {
+      $window.location.hash = '#/volunteer/opportunities';
+    };
+  });
+
+})(angular, CRM.$, CRM._);

--- a/ang/volunteer/VolOppsCtrl.html
+++ b/ang/volunteer/VolOppsCtrl.html
@@ -8,6 +8,9 @@ Required vars: volOppData(), searchParams
     <p>
       {{helpText()}}
     </p>
+    <p>
+      <a href="#/volunteer/my-shifts">{{:: ts('Manage the shifts you have already signed up for') }}</a>
+    </p>
   </div>
 
   <!-- Search Form -->

--- a/volunteer.php
+++ b/volunteer.php
@@ -463,11 +463,102 @@ function volunteer_civicrm_alterAPIPermissions($entity, $action, &$params, &$per
   $permissions['volunteer_util']['default'] = array('edit own volunteer projects');
   $permissions['volunteer_project_contact']['default'] = array('edit own volunteer projects');
 
+  // VOL: Allow volunteers to manage (view/edit/delete) their own assignments
+  // without needing project-level permissions. When a VolunteerAssignment API
+  // call targets only the logged-in contact's own records, the "register to
+  // volunteer" permission is sufficient.
+  if ($entity === 'volunteer_assignment'
+    && _volunteer_isOwnAssignmentCall($action, $params)
+  ) {
+    $permissions['volunteer_assignment'][$action] = array('register to volunteer');
+  }
 
   // allow fairly liberal access to the volunteer opp listing UI, which uses lots of API calls
   if (_volunteer_isVolListingApiCall($entity, $action) && CRM_Volunteer_Permission::checkProjectPerms(CRM_Core_Action::VIEW)) {
     $params['check_permissions'] = FALSE;
   }
+}
+
+/**
+ * Determines whether a VolunteerAssignment API call is scoped to the logged-in
+ * contact's own assignments.
+ *
+ * For get, the params must restrict assignee_contact_id to the logged-in
+ * contact. For create (update) and delete, the existing assignment referenced
+ * by id must be assigned to the logged-in contact. Create-without-id (new
+ * signup) is not considered a self-service operation here; signup flows
+ * through CRM_Volunteer_Form_VolunteerSignUp which has its own permission
+ * gate.
+ *
+ * @param string $action
+ * @param array $params
+ * @return bool
+ */
+function _volunteer_isOwnAssignmentCall($action, array $params) {
+  $contactId = CRM_Core_Session::getLoggedInContactID();
+  if (empty($contactId)) {
+    return FALSE;
+  }
+
+  switch ($action) {
+    case 'get':
+    case 'getsingle':
+    case 'getcount':
+      $assignee = $params['assignee_contact_id'] ?? NULL;
+      if ($assignee === 'user_contact_id') {
+        return TRUE;
+      }
+      return !empty($assignee) && (int) $assignee === (int) $contactId;
+
+    case 'create':
+      // Only permit self-service for updates of an existing assignment; new
+      // signups must go through the VolunteerSignUp form.
+      if (empty($params['id'])) {
+        return FALSE;
+      }
+      return _volunteer_assignmentBelongsToContact($params['id'], $contactId);
+
+    case 'delete':
+      if (empty($params['id'])) {
+        return FALSE;
+      }
+      return _volunteer_assignmentBelongsToContact($params['id'], $contactId);
+  }
+
+  return FALSE;
+}
+
+/**
+ * Checks whether a given volunteer assignment (activity) is assigned to the
+ * specified contact.
+ *
+ * @param int $activityId
+ * @param int $contactId
+ * @return bool
+ */
+function _volunteer_assignmentBelongsToContact($activityId, $contactId) {
+  $activityId = (int) $activityId;
+  $contactId = (int) $contactId;
+  if (!$activityId || !$contactId) {
+    return FALSE;
+  }
+
+  $activityContactTypes = CRM_Core_OptionGroup::values('activity_contacts', FALSE, FALSE, FALSE, NULL, 'name');
+  $assigneeRecordTypeId = (int) CRM_Utils_Array::key('Activity Assignees', $activityContactTypes);
+  if (!$assigneeRecordTypeId) {
+    return FALSE;
+  }
+
+  $count = CRM_Core_DAO::singleValueQuery(
+    "SELECT COUNT(*) FROM civicrm_activity_contact
+      WHERE activity_id = %1 AND contact_id = %2 AND record_type_id = %3",
+    array(
+      1 => array($activityId, 'Integer'),
+      2 => array($contactId, 'Integer'),
+      3 => array($assigneeRecordTypeId, 'Integer'),
+    )
+  );
+  return (int) $count > 0;
 }
 
 /**


### PR DESCRIPTION
Previously the VolunteerAssignment API required project-level permissions (edit own volunteer projects), so volunteers could not view, edit, or cancel their own signups without an admin touching the record.

This change relaxes the VolunteerAssignment API permission when the call targets only the logged-in contact's own records: the existing "register to volunteer" permission is then sufficient. The check is scoped tightly - get/getsingle must filter on assignee_contact_id, and create/delete must reference an assignment whose assignee is the logged-in contact. New signups still flow through VolunteerSignUp.

Adds a "My Shifts" Angular page at #/volunteer/my-shifts where volunteers can list their signups, edit the scheduled/completed minutes and notes, or cancel a shift outright. A link to the page is surfaced from the opportunity search view.